### PR TITLE
Add ccy.q (currency pair convention) and sweepPrice (book-depth pricing)

### DIFF
--- a/.claude/skills/kdb-q-conventions/SKILL.md
+++ b/.claude/skills/kdb-q-conventions/SKILL.md
@@ -94,14 +94,22 @@ library with no processes/IPC/tables).
   reduce a vector comparison to a scalar first (e.g. `max abs a-b` against
   a tolerance) rather than asserting on the two vectors directly - smaller
   results table, and a far more readable failure message too.
+- `string` on a value that's **already a string** (type `10h`) does not
+  act as the identity - it maps over each character and returns a list of
+  1-char strings (`string "EURUSD"` gives `("E";"U";"R";...)`, not
+  `"EURUSD"`). Only `string` on a symbol correctly returns the whole thing
+  as one string. `ccy.q`'s `ccyToStr` exists specifically to paper over
+  this: `$[10h=type x; x; string x]` - check `type` before coercing
+  anything that might already be a string.
 
 ## Layout
 
 - `src/*.q` - one module per topic, each wrapped in `\d .uqf` ... `\d .` so
   everything lands in the `.uqf` namespace. Load order doesn't matter for
   function *definitions* (q resolves names at call time), but `src/init.q`
-  loads them in a sensible dependency order (stats -> daycount -> rates ->
-  forwards -> options -> risk -> execution).
+  loads them in a sensible dependency order (stats -> ccy -> daycount ->
+  rates -> forwards -> options -> risk -> execution). `forwards.q`'s
+  `crossBook` depends on `ccy.q`'s `ccyPairLegs`/`ccyPairSymbol`.
 - `tests/lib/qunit.q` - vendored TimeStored qUnit framework (CC BY-NC-SA,
   non-commercial - keep the attribution header intact; see README's
   Licensing section before using this repo commercially).
@@ -181,6 +189,15 @@ running `com.timestored.qdoc.QDocMain` against a scratch file:
 - qDoc documents `.uqf` separately per source file in its nav
   (`.uqf (options.q)`, `.uqf (risk.q)`, ...) rather than merging same-named
   namespaces from different files into one page - expected, not a bug.
+- **Never write a literal `<` in doc text** (descriptions, `@return`,
+  `@throws`, etc.) - qDoc drops it and everything after it into the HTML
+  unescaped, so a naive HTML parser treats `<=0` or `<rd` as the start of
+  a tag and the rest of that line silently vanishes from the rendered
+  page (this happened to `ncdf`'s `@return`, `carryReturn`'s description,
+  and `sweepPrice`'s `@throws` - all originally used `<` or `<=`). A bare
+  `>` is fine (confirmed via `bookCrossed`'s "bid>ask" rendering intact).
+  Rephrase in words ("x is at most y", "targetSize is not positive")
+  instead of using the character.
 - qstudio.jar also runs a bundled linter as a side effect
   (`docs/lint.csv`), which throws a lot of `UNDECLARED_VAR` false
   positives for this repo specifically, because it lints each file in

--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ Every function lives in the `.uqf` namespace after loading `src/init.q`.
 ```
 src/
   stats.q       normal distribution helpers (ncdf, npdf, invNcdf) + hornerEval
+  ccy.q         currency pair symbol convention: CURCUR validation/normalization
   daycount.q    day count fraction conventions (ACT/360, ACT/365, 30E/360)
   rates.q       discount/growth factors, simple<->continuous rate conversion
   forwards.q    CIRP forwards/swap points, cross rates, synthetic cross books
   options.q     Garman-Kohlhagen pricing, Greeks, implied vol
   risk.q        pip value, P&L, carry, parametric & historical VaR
-  execution.q   markouts, effective spread, slippage, fill/reject ratios, vwap
+  execution.q   markouts, effective spread, slippage, fill/reject ratios,
+                vwap, order-book sweep pricing
   init.q        loads every module above, in dependency order
 
 tests/
@@ -77,6 +79,12 @@ scripts/
 approximation to the inverse normal CDF), `hornerEval` (shared polynomial
 evaluator every other module's math routes through).
 
+**ccy.q** - `isCcyPair`/`normalizeCcyPair` (canonical CURCUR convention -
+six uppercase letters, no separator - validated/normalized from looser
+input like `` `eurusd `` or `"EUR/USD"``), `ccyPairSymbol`/`ccyPairLegs`
+(build/split a pair symbol from its 3-letter base and quote currency
+codes). `forwards.q`'s `crossBook` uses these internally.
+
 **daycount.q** - `dcfAct360`, `dcfAct365`, `dcf30E360`, and `yearFrac`
 which dispatches to one of them by convention symbol (`` `act360``,
 `` `act365``, `` `30e360``). Turns a pair of dates into the year fraction
@@ -87,7 +95,10 @@ which dispatches to one of them by convention symbol (`` `act360``,
 
 **forwards.q** - `fwdSimple`/`fwdCont` (CIRP outright), `fwdPoints`,
 `pointsToOutright`, `impliedForeignRate`/`impliedDomesticRate`,
-`crossRate`/`invertRate`, and `crossBook`/`invertBook`/
+`crossRate`/`invertRate` (A/B * B/C = A/C chain), `crossRateSharedBase`
+(divide - two rates sharing a currency on the *same* side, e.g. EURPLN &
+EURUSD -> USDPLN; a 3+-leg cross like AUDPLN from AUDUSD/EURUSD/EURPLN is
+just composing this with `crossRate`), and `crossBook`/`invertBook`/
 `combineOrientedBooks`/`bookCrossed` for building a synthetic top-of-book
 cross rate from two live order books (auto-detects the shared currency and
 orients/inverts each leg as needed).
@@ -102,7 +113,9 @@ Setting `rf=0` reduces Garman-Kohlhagen to plain Black-Scholes.
 
 **execution.q** - `markout` (vectorizes naturally across multiple
 post-trade horizons), `effSpread`, `slippage`, `fillRatio`, `rejectRatio`,
-`vwap`.
+`vwap`, `sweepPrice` (walks best-to-worst order book levels to price
+sweeping a given size - the blended fill price, the marginal/worst level
+touched, how much actually filled, and whether the book had enough depth).
 
 Currency pairs follow BASE/QUOTE quoting throughout (`rate` = 1 BASE in
 QUOTE units); `side` is `1` for long/buy, `-1` for short/sell;
@@ -118,7 +131,7 @@ q tests/run_tests.q
 
 This loads every module, loads every `test_*.q` file, runs the full qUnit
 suite, prints a pass/fail summary, and exits non-zero if anything failed -
-safe to wire into CI as-is. As of this writing: **135 tests, all passing**.
+safe to wire into CI as-is. As of this writing: **174 tests, all passing**.
 
 Every function is tested against at least one of: a published textbook
 reference value (e.g. Hull's Black-Scholes worked example for

--- a/src/ccy.q
+++ b/src/ccy.q
@@ -1,0 +1,72 @@
+/ ccy.q - currency pair symbol conventions: canonical CURCUR validation and
+/ normalization from looser input formats (lowercase, with separators).
+/ .
+/ Canonical form used throughout this library is CURCUR - six uppercase
+/ letters, no separator, e.g. `EURUSD (not `eurusd, not "EUR/USD").
+
+\d .uqf
+
+/ Private: string-coerce x without exploding an already-string input into
+/ a list of 1-char strings - `string` on a char vector maps over each
+/ char instead of acting as the identity, which is a real q gotcha.
+/ @param x a symbol or string
+/ @return x as a plain string
+/ @eg .uqf.ccyToStr `EURUSD  -> "EURUSD"
+ccyToStr:{[x] $[10h=type x; x; string x]};
+
+/ True if x is already in canonical CURCUR form: exactly 6 uppercase
+/ letters, no separator.
+/ @param x a symbol or string
+/ @return 1b if x is a valid CURCUR pair, else 0b
+/ @eg .uqf.isCcyPair `EURUSD  -> 1b
+/ @eg .uqf.isCcyPair "eur/usd"  -> 0b
+isCcyPair:{[x]
+    s:ccyToStr x;
+    lengthOk:(count s)=6;
+    allLetters:all s in .Q.A;
+    lengthOk and allLetters};
+
+/ Normalize a currency pair into canonical CURCUR form: uppercases and
+/ strips common separators (/, -, _, space).
+/ @param x a symbol or string, e.g. `eurusd, "EUR/USD", "eur-usd"
+/ @return the canonical CURCUR symbol, e.g. `EURUSD
+/ @throws error if x cannot be normalized to a 6-letter CURCUR pair
+/ @eg .uqf.normalizeCcyPair "eur/usd"  -> `EURUSD
+normalizeCcyPair:{[x]
+    s:ccyToStr x;
+    noSlash:ssr[s;"/";""];
+    noDash:ssr[noSlash;"-";""];
+    noUnderscore:ssr[noDash;"_";""];
+    noSpace:ssr[noUnderscore;" ";""];
+    canonical:upper noSpace;
+    if[not isCcyPair canonical; '"normalizeCcyPair: cannot normalize '",s,"' to a 6-letter CURCUR pair"];
+    `$canonical};
+
+/ Build a canonical CURCUR pair symbol from a 3-letter base and quote
+/ currency code.
+/ @param base 3-letter base currency code, e.g. `EUR or "eur"
+/ @param quote 3-letter quote currency code, e.g. `USD or "usd"
+/ @return the canonical CURCUR symbol, e.g. `EURUSD
+/ @throws error if base or quote is not a 3-letter alphabetic code
+/ @eg .uqf.ccyPairSymbol[`EUR;`USD]  -> `EURUSD
+ccyPairSymbol:{[base;quote]
+    b:upper ccyToStr base;
+    q:upper ccyToStr quote;
+    if[(count b)<>3; '"ccyPairSymbol: base currency code must be 3 letters, got '",b,"'"];
+    if[(count q)<>3; '"ccyPairSymbol: quote currency code must be 3 letters, got '",q,"'"];
+    if[not all b in .Q.A; '"ccyPairSymbol: base currency code must be letters, got '",b,"'"];
+    if[not all q in .Q.A; '"ccyPairSymbol: quote currency code must be letters, got '",q,"'"];
+    `$b,q};
+
+/ Split a currency pair (any reasonable format - normalized first) into
+/ its base and quote 3-letter currency codes.
+/ @param pair a symbol or string, e.g. `EURUSD, "eur/usd"
+/ @return dict `base`quote!(baseSym;quoteSym)
+/ @throws error if pair cannot be normalized to a 6-letter CURCUR pair
+/ @eg .uqf.ccyPairLegs `EURUSD  -> `base`quote!(`EUR;`USD)
+ccyPairLegs:{[pair]
+    canonical:normalizeCcyPair pair;
+    s:string canonical;
+    `base`quote!(`$3#s;`$-3#s)};
+
+\d .

--- a/src/execution.q
+++ b/src/execution.q
@@ -67,4 +67,37 @@ vwap:{[prices;sizes]
     totalSize:sum sizes;
     weightedSum%totalSize};
 
+/ Walk a stack of order book levels to price a sweep of targetSize: the
+/ blended price you'd get consuming best-to-worst levels until targetSize
+/ is filled or the book runs out. Pass the ask side (best/lowest price
+/ first) to price a buy/sweep-the-offer, or the bid side (best/highest
+/ price first) to price a sell/sweep-the-bid - this function doesn't care
+/ which side it is, only that prices/sizes are already ordered best-first.
+/ @param prices level prices, best (most aggressive) first
+/ @param sizes level sizes, same length as prices, aligned to the same levels
+/ @param targetSize the size you want to sweep
+/ @return dict `avgPrice`worstPrice`filledSize`fullyFilled - avgPrice is
+/   the size-weighted blended execution price (null if nothing filled),
+/   worstPrice is the price of the last level touched (the marginal fill,
+/   null if nothing filled), filledSize is how much actually filled (may
+/   be less than targetSize if the book doesn't have enough depth), and
+/   fullyFilled is 1b iff filledSize>=targetSize
+/ @throws error if targetSize is not positive, or prices/sizes differ in length
+/ @eg .uqf.sweepPrice[1.1000 1.1002 1.1005;1000000 1000000 2000000;3000000]  -> `avgPrice`worstPrice`filledSize`fullyFilled!(1.100233;1.1005;3000000;1b)
+sweepPrice:{[prices;sizes;targetSize]
+    if[targetSize<=0; '"sweepPrice: size must be positive"];
+    if[(count prices)<>count sizes; '"sweepPrice: prices and sizes must be the same length"];
+    cumSize:sums sizes;
+    priorCum:cumSize-sizes;
+    cappedCum:targetSize&cumSize;
+    rawConsumed:cappedCum-priorCum;
+    consumed:0|rawConsumed;
+    filledSize:sum consumed;
+    notional:sum consumed*prices;
+    avgPrice:$[filledSize>0; notional%filledSize; 0n];
+    touchedIdx:where consumed>0;
+    worstPrice:$[count touchedIdx; prices last touchedIdx; 0n];
+    fullyFilled:filledSize>=targetSize;
+    `avgPrice`worstPrice`filledSize`fullyFilled!(avgPrice;worstPrice;filledSize;fullyFilled)};
+
 \d .

--- a/src/forwards.q
+++ b/src/forwards.q
@@ -79,6 +79,19 @@ crossRate:{[abRate;bcRate] abRate*bcRate};
 / @eg .uqf.invertRate 2f  -> 0.5
 invertRate:{[rate] 1%rate};
 
+/ Cross rate via a shared base currency: given two pairs both quoted
+/ A/X and A/Y (e.g. EURPLN and EURUSD both quoted against EUR), returns
+/ the Y/X cross rate - the common eFX pattern of computing e.g. USDPLN
+/ from EURPLN and EURUSD as EURPLN * (1/EURUSD). Simply crossRate composed
+/ with invertRate; kept as its own named function because "invert the
+/ second one, not the first" is exactly the kind of thing that's easy to
+/ get backwards at the desk.
+/ @param rateAX rate for A/X (the shared base A over the first quote currency X)
+/ @param rateAY rate for A/Y (the shared base A over the second quote currency Y)
+/ @return the implied rate for Y/X
+/ @eg .uqf.crossRateSharedBase[4.30;1.075]  -> 4f (EURPLN, EURUSD -> USDPLN)
+crossRateSharedBase:{[rateAX;rateAY] crossRate[rateAX;invertRate rateAY]};
+
 / Invert an order book: BASE/QUOTE -> QUOTE/BASE. Inverting flips which
 / side is more favourable, so the new bid comes from the old ask and vice
 / versa.
@@ -111,35 +124,36 @@ bookCrossed:{[book] book[`bid]>book[`ask]};
 / pairs that share a common currency, e.g. crossBook[`EURUSD;eurusdBook;
 / `USDJPY;usdjpyBook] -> a synthetic EURJPY book. The shared currency is
 / detected automatically and either leg is inverted as needed - the
-/ caller does not need to pre-orient anything. Combines top-of-book only;
-/ it does not walk/net multiple depth levels of the underlying books.
-/ @param sym1 6-character currency pair symbol for book1, e.g. `EURUSD
+/ caller does not need to pre-orient anything. sym1/sym2 are normalized
+/ via ccy.q's ccyPairLegs, so `eurusd, "eur/usd" etc. work too, not just
+/ canonical `EURUSD. Combines top-of-book only; it does not walk/net
+/ multiple depth levels of the underlying books.
+/ @param sym1 currency pair for book1, any format ccy.q's normalizeCcyPair accepts
 / @param book1 dict `bid`ask!(bidPx;askPx) quoted in sym1's own convention
-/ @param sym2 6-character currency pair symbol for book2, e.g. `USDJPY
+/ @param sym2 currency pair for book2, any format ccy.q's normalizeCcyPair accepts
 / @param book2 dict `bid`ask!(bidPx;askPx) quoted in sym2's own convention
 / @return dict `sym`bid`ask!(crossSym;bidPx;askPx) for the synthetic cross
 / @throws error if sym1 and sym2 share no common currency
 / @eg .uqf.crossBook[`EURUSD;`bid`ask!(1.1000;1.1002);`USDJPY;`bid`ask!(150.00;150.02)]  -> `sym`bid`ask!(`EURJPY;165;165.052)
 crossBook:{[sym1;book1;sym2;book2]
-    s1:string sym1; s2:string sym2;
-    base1:3#s1; quote1:-3#s1;
-    base2:3#s2; quote2:-3#s2;
+    legs1:ccyPairLegs sym1; base1:string legs1`base; quote1:string legs1`quote;
+    legs2:ccyPairLegs sym2; base2:string legs2`base; quote2:string legs2`quote;
     if[quote1~base2;
-        crossSym:`$base1,quote2;
+        crossSym:ccyPairSymbol[base1;quote2];
         combined:combineOrientedBooks[book1;book2];
         :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
     if[quote1~quote2;
-        crossSym:`$base1,base2;
+        crossSym:ccyPairSymbol[base1;base2];
         combined:combineOrientedBooks[book1;invertBook book2];
         :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
     if[base1~base2;
-        crossSym:`$quote1,quote2;
+        crossSym:ccyPairSymbol[quote1;quote2];
         combined:combineOrientedBooks[invertBook book1;book2];
         :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
     if[base1~quote2;
-        crossSym:`$quote1,base2;
+        crossSym:ccyPairSymbol[quote1;base2];
         combined:combineOrientedBooks[invertBook book1;invertBook book2];
         :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
-    '"crossBook: no shared currency between ",s1," and ",s2};
+    '"crossBook: no shared currency between ",base1,quote1," and ",base2,quote2};
 
 \d .

--- a/src/init.q
+++ b/src/init.q
@@ -2,6 +2,7 @@
 // Run from the repository root, e.g. `q src/init.q` or `\l src/init.q`.
 
 \l src/stats.q
+\l src/ccy.q
 \l src/daycount.q
 \l src/rates.q
 \l src/forwards.q

--- a/src/risk.q
+++ b/src/risk.q
@@ -23,7 +23,7 @@ pnl:{[notional;entryRate;exitRate;side] side*notional*(exitRate-entryRate)};
 
 / Forward premium/discount implied by spot vs. an outright, as a decimal
 / return: (F-S)/S. Positive means the base currency trades forward at a
-/ premium (i.e. rf<rd under CIRP).
+/ premium (i.e. rf is below rd under CIRP).
 / @param spot spot rate
 / @param fwd outright forward rate
 / @return the decimal forward premium/discount

--- a/src/stats.q
+++ b/src/stats.q
@@ -33,7 +33,7 @@ npdf:{[x] exp[-0.5*x*x] % sqrt 2*PI};
 
 / Standard normal cumulative distribution function N(x).
 / @param x point(s) to evaluate at (atom or vector)
-/ @return P(Z<=x) for a standard normal Z
+/ @return P(Z is at most x) for a standard normal Z
 / @eg .uqf.ncdf 1.96  -> 0.9750022
 ncdf:{[x]
     coeffs:1.061405429 -1.453152027 1.421413741 -0.284496736 0.254829592 0f; / a5 a4 a3 a2 a1 0, highest degree first

--- a/tests/run_tests.q
+++ b/tests/run_tests.q
@@ -7,6 +7,7 @@
 \l src/init.q
 
 \l tests/test_stats.q
+\l tests/test_ccy.q
 \l tests/test_daycount.q
 \l tests/test_rates.q
 \l tests/test_forwards.q
@@ -15,7 +16,7 @@
 \l tests/test_execution.q
 \l tests/test_execution_scale.q
 
-nsList:`.statstest`.daycounttest`.ratestest`.forwardstest`.optionstest`.risktest`.executiontest`.executionscaletest;
+nsList:`.statstest`.ccytest`.daycounttest`.ratestest`.forwardstest`.optionstest`.risktest`.executiontest`.executionscaletest;
 res:.qunit.runTests[nsList];
 
 nTotal:count res;

--- a/tests/test_ccy.q
+++ b/tests/test_ccy.q
@@ -1,0 +1,62 @@
+// test_ccy.q - tests for src/ccy.q (currency pair symbol conventions).
+// Load src/ccy.q, tests/lib/qunit.q and tests/lib/testutil.q before this
+// file.
+
+\d .ccytest
+
+testCcyToStrSymbol:{[t] .qunit.assertEquals[.uqf.ccyToStr `EURUSD;"EURUSD";"symbol -> string"]};
+testCcyToStrAlreadyString:{[t] .qunit.assertEquals[.uqf.ccyToStr "EURUSD";"EURUSD";"string stays a single string, not exploded into chars"]};
+
+testIsCcyPairCanonicalSymbol:{[t] .qunit.assertTrue[.uqf.isCcyPair `EURUSD;"canonical symbol is valid"]};
+testIsCcyPairCanonicalString:{[t] .qunit.assertTrue[.uqf.isCcyPair "EURUSD";"canonical string is valid"]};
+testIsCcyPairRejectsLowercase:{[t] .qunit.assertFalse[.uqf.isCcyPair `eurusd;"lowercase symbol is rejected"]};
+testIsCcyPairRejectsMixedCase:{[t] .qunit.assertFalse[.uqf.isCcyPair "EurUsd";"mixed case is rejected"]};
+testIsCcyPairRejectsSlash:{[t] .qunit.assertFalse[.uqf.isCcyPair "EUR/USD";"separator is rejected"]};
+testIsCcyPairRejectsWrongLength:{[t] .qunit.assertFalse[.uqf.isCcyPair "EURUS";"5 chars is rejected"]};
+testIsCcyPairRejectsDigits:{[t] .qunit.assertFalse[.uqf.isCcyPair "EUR123";"digits are rejected"]};
+testIsCcyPairRejectsEmpty:{[t] .qunit.assertFalse[.uqf.isCcyPair "";"empty string is rejected"]};
+
+testNormalizeCcyPairLowercaseSymbol:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair `eurusd;`EURUSD;"lowercase symbol normalizes"]};
+testNormalizeCcyPairSlash:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair "EUR/USD";`EURUSD;"slash separator stripped"]};
+testNormalizeCcyPairLowercaseSlash:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair "eur/usd";`EURUSD;"lowercase + slash normalizes"]};
+testNormalizeCcyPairDash:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair "eur-usd";`EURUSD;"dash separator stripped"]};
+testNormalizeCcyPairUnderscore:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair "eur_usd";`EURUSD;"underscore separator stripped"]};
+testNormalizeCcyPairSpace:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair "eur usd";`EURUSD;"space separator stripped"]};
+testNormalizeCcyPairAlreadyCanonical:{[t] .qunit.assertEquals[.uqf.normalizeCcyPair `EURUSD;`EURUSD;"already-canonical input is a no-op"]};
+testNormalizeCcyPairRejectsUnrecoverable:{[t]
+    wrapper:{[x] .uqf.normalizeCcyPair "EURUSDX"};
+    .qunit.assertError[wrapper;::;"cannot normalize a 7-letter mess into CURCUR"]};
+
+testCcyPairSymbolKnown:{[t] .qunit.assertEquals[.uqf.ccyPairSymbol[`EUR;`USD];`EURUSD;"builds EURUSD from EUR, USD"]};
+testCcyPairSymbolLowercaseInputs:{[t] .qunit.assertEquals[.uqf.ccyPairSymbol["eur";"usd"];`EURUSD;"lowercase inputs still build canonical output"]};
+testCcyPairSymbolRejectsWrongLengthBase:{[t]
+    wrapper:{[x] .uqf.ccyPairSymbol[`EU;`USD]};
+    .qunit.assertError[wrapper;::;"2-letter base is rejected"]};
+testCcyPairSymbolRejectsWrongLengthQuote:{[t]
+    wrapper:{[x] .uqf.ccyPairSymbol[`EUR;`USDX]};
+    .qunit.assertError[wrapper;::;"4-letter quote is rejected"]};
+testCcyPairSymbolRejectsNonAlpha:{[t]
+    wrapper:{[x] .uqf.ccyPairSymbol[`EUR;`123]};
+    .qunit.assertError[wrapper;::;"non-alphabetic quote is rejected"]};
+
+testCcyPairLegsKnown:{[t]
+    legs:.uqf.ccyPairLegs `EURUSD;
+    .qunit.assertEquals[legs`base;`EUR;"base leg"];
+    .qunit.assertEquals[legs`quote;`USD;"quote leg"]};
+testCcyPairLegsAcceptsLooseFormat:{[t]
+    legs:.uqf.ccyPairLegs "eur/usd";
+    .qunit.assertEquals[legs`base;`EUR;"base leg from loose format"];
+    .qunit.assertEquals[legs`quote;`USD;"quote leg from loose format"]};
+
+testCcyPairSymbolAndLegsRoundTrip:{[t]
+    pairs:`EURUSD`GBPJPY`AUDNZD`USDCHF;
+    legsList:.uqf.ccyPairLegs each pairs;
+    rebuilt:{.uqf.ccyPairSymbol[x`base;x`quote]} each legsList;
+    .qunit.assertEquals[rebuilt;pairs;"split then rebuild returns the original pairs"]};
+
+testNormalizeCcyPairIdempotent:{[t]
+    once:.uqf.normalizeCcyPair "eur/usd";
+    twice:.uqf.normalizeCcyPair once;
+    .qunit.assertEquals[once;twice;"normalizing an already-normalized pair is a no-op"]};
+
+\d .

--- a/tests/test_execution.q
+++ b/tests/test_execution.q
@@ -41,4 +41,63 @@ testVwapEqualSizesEqualsSimpleAverage:{[t]
     sizes:1000000 1000000 1000000 1000000;
     .testutil.assertApprox[.uqf.vwap[prices;sizes];avg prices;1e-9;"equal sizes -> vwap reduces to the plain average"]};
 
+testSweepPriceWalksMultipleLevels:{[t]
+    / 1M@1.1000, 1M@1.1002, 2M@1.1005 -- sweep 3M walks all of level 1,
+    / all of level 2, and 1M of the 2M available at level 3
+    prices:1.1000 1.1002 1.1005;
+    sizes:1000000 1000000 2000000;
+    r:.uqf.sweepPrice[prices;sizes;3000000];
+    .testutil.assertApprox[r`avgPrice;1.100233333;1e-6;"blended sweep price across three levels"];
+    .testutil.assertApprox[r`worstPrice;1.1005;1e-9;"worst (marginal) price is the last level touched"];
+    .testutil.assertApprox[r`filledSize;3000000f;1e-9;"filled size matches the requested size"];
+    .qunit.assertTrue[r`fullyFilled;"fully filled when the book has enough depth"]};
+
+testSweepPriceFitsInsideFirstLevel:{[t]
+    prices:1.1000 1.1002 1.1005;
+    sizes:1000000 1000000 2000000;
+    r:.uqf.sweepPrice[prices;sizes;500000];
+    .testutil.assertApprox[r`avgPrice;1.1000;1e-9;"size smaller than top level fills entirely at the top price"];
+    .testutil.assertApprox[r`worstPrice;1.1000;1e-9;"worst price equals the top price when only one level is touched"];
+    .qunit.assertTrue[r`fullyFilled;"fully filled"]};
+
+testSweepPriceExactLevelBoundary:{[t]
+    prices:1.1000 1.1002 1.1005;
+    sizes:1000000 1000000 2000000;
+    r:.uqf.sweepPrice[prices;sizes;1000000];
+    .testutil.assertApprox[r`avgPrice;1.1000;1e-9;"sweeping exactly one level's size stays entirely within that level"];
+    .testutil.assertApprox[r`worstPrice;1.1000;1e-9;"worst price is still the top level"]};
+
+testSweepPriceInsufficientLiquidity:{[t]
+    / total depth is 4M; asking for 5M can only get 4M filled
+    prices:1.1000 1.1002 1.1005;
+    sizes:1000000 1000000 2000000;
+    r:.uqf.sweepPrice[prices;sizes;5000000];
+    .testutil.assertApprox[r`filledSize;4000000f;1e-9;"filled size caps at total available depth"];
+    .testutil.assertApprox[r`worstPrice;1.1005;1e-9;"worst price is the last (deepest) level available"];
+    .qunit.assertFalse[r`fullyFilled;"not fully filled when requested size exceeds total depth"]};
+
+testSweepPriceOfFullDepthEqualsVwap:{[t]
+    / sweeping exactly the book's total size is the same as vwap over the whole book
+    prices:1.1000 1.1002 1.1005 1.1009;
+    sizes:1000000 1000000 2000000 1500000;
+    totalSize:sum sizes;
+    r:.uqf.sweepPrice[prices;sizes;totalSize];
+    .testutil.assertApprox[r`avgPrice;.uqf.vwap[prices;sizes];1e-9;"sweeping full depth = vwap of the whole book"]};
+
+testSweepPriceEmptyBookFillsNothing:{[t]
+    r:.uqf.sweepPrice[`float$();`float$();1000000];
+    .testutil.assertApprox[r`filledSize;0f;1e-9;"empty book fills nothing"];
+    .qunit.assertFalse[r`fullyFilled;"empty book cannot be fully filled"];
+    .qunit.assertTrue[null r`avgPrice;"avgPrice is null when nothing filled"];
+    .qunit.assertTrue[null r`worstPrice;"worstPrice is null when nothing filled"]};
+
+testSweepPriceRejectsNonPositiveSize:{[t]
+    wrapper:{[x] .uqf.sweepPrice[1.10 1.11;100 100;x]};
+    .qunit.assertError[wrapper;0;"zero size is rejected"];
+    .qunit.assertError[wrapper;-5;"negative size is rejected"]};
+
+testSweepPriceRejectsMismatchedLengths:{[t]
+    wrapper:{[x] .uqf.sweepPrice[1.10 1.11;enlist 100;500]};
+    .qunit.assertError[wrapper;::;"mismatched prices/sizes lengths are rejected"]};
+
 \d .

--- a/tests/test_forwards.q
+++ b/tests/test_forwards.q
@@ -54,12 +54,33 @@ testInvertRateRoundTrip:{[t]
 
 testInvertRateKnown:{[t] .testutil.assertApprox[.uqf.invertRate 2f;0.5;1e-9;"1/2=0.5"]};
 
+testCrossRateSharedBaseKnown:{[t]
+    / EURPLN=4.30, EURUSD=1.075 -> USDPLN=4.30/1.075=4.0 exactly
+    .testutil.assertApprox[.uqf.crossRateSharedBase[4.30;1.075];4f;1e-9;"EURPLN, EURUSD -> USDPLN"]};
+
+testCrossRateSharedBaseMatchesManualComposition:{[t]
+    rateAX:1.3427; rateAY:0.7231;
+    lhs:.uqf.crossRateSharedBase[rateAX;rateAY];
+    rhs:.uqf.crossRate[rateAX;.uqf.invertRate rateAY];
+    .testutil.assertApprox[lhs;rhs;1e-9;"crossRateSharedBase = crossRate composed with invertRate on the second leg"]};
+
+testCrossRateSharedBaseIdentityWhenPairsEqual:{[t]
+    / A/X and A/Y with X=Y (same rate on both legs) -> Y/X = 1
+    .testutil.assertApprox[.uqf.crossRateSharedBase[1.2500;1.2500];1f;1e-9;"identical shared-base rates cross to exactly 1"]};
+
+testCrossRateSharedBaseAntiSymmetric:{[t]
+    / swapping which pair is "X" and which is "Y" inverts the result
+    rateAX:1.10; rateAY:150.0;
+    fwd:.uqf.crossRateSharedBase[rateAX;rateAY];
+    back:.uqf.crossRateSharedBase[rateAY;rateAX];
+    .testutil.assertApprox[fwd*back;1f;1e-9;"swapping the two legs gives the inverse cross rate"]};
+
 testInvertBookSwapsSides:{[t]
     book:`bid`ask!(1.1000;1.1002);
-    inv:.uqf.invertBook book;
+    inverted:.uqf.invertBook book;
     expected:`bid`ask!(1%1.1002;1%1.1000);
-    .testutil.assertApprox[inv`bid;expected`bid;1e-9;"inverted bid = 1/original ask"];
-    .testutil.assertApprox[inv`ask;expected`ask;1e-9;"inverted ask = 1/original bid"]};
+    .testutil.assertApprox[inverted`bid;expected`bid;1e-9;"inverted bid = 1/original ask"];
+    .testutil.assertApprox[inverted`ask;expected`ask;1e-9;"inverted ask = 1/original bid"]};
 
 testInvertBookRoundTrip:{[t]
     book:`bid`ask!(1.2500;1.2503);


### PR DESCRIPTION
## Summary
- **ccy.q**: `isCcyPair`/`normalizeCcyPair` enforce and normalize the canonical CURCUR convention (six uppercase letters, no separator) from looser input like `` `eurusd `` or `"EUR/USD"`; `ccyPairSymbol`/`ccyPairLegs` build/split a pair from its 3-letter legs. `forwards.q`'s `crossBook` is refactored to reuse these instead of its own inline string-slicing (and now accepts loose formats too, as a side effect).
- **crossRateSharedBase** (`forwards.q`): the "shared corner" 2-leg cross (divide, e.g. EURPLN & EURUSD -> USDPLN), complementing the existing chain-form `crossRate` (multiply, A/B*B/C=A/C) - composing the two prices any N-leg cross (e.g. AUDPLN via AUDUSD/EURUSD/EURPLN) through whatever currencies connect.
- **sweepPrice** (`execution.q`): walks best-to-worst order book levels to price sweeping a given size - returns the blended fill price, the worst/marginal level touched, how much actually filled, and whether the book had enough depth.
- Fixes a qDoc HTML-escaping bug found while documenting `sweepPrice`: a literal `<` in doc text gets swallowed by qDoc's unescaped HTML output, silently truncating the rendered description on three functions - rephrased in words instead.
- All gotchas hit while building this are recorded in the `kdb-q-conventions` skill.

## Test plan
- [x] Full qUnit suite: 174/174 passing (`q tests/run_tests.q`)
- [x] Every new `@eg` doc example verified against actual function output
- [x] qDoc HTML regenerated and spot-checked (no more truncated descriptions)
- [x] `crossBook` refactor re-verified against all 25 pre-existing `forwards.q` tests
- [x] `sweepPrice` edge cases covered: multi-level walk, fits-in-top-level, exact level boundary, insufficient liquidity, full-depth-equals-vwap identity, empty book, invalid size/length errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)