### PR TITLE
Add crossBookAtSizes: depth-aware, size/side-parameterized cross rates

### DIFF
--- a/.claude/skills/kdb-q-conventions/SKILL.md
+++ b/.claude/skills/kdb-q-conventions/SKILL.md
@@ -101,6 +101,32 @@ library with no processes/IPC/tables).
   as one string. `ccy.q`'s `ccyToStr` exists specifically to paper over
   this: `$[10h=type x; x; string x]` - check `type` before coercing
   anything that might already be a string.
+- **`,` on two symbol atoms does not concatenate their text** - it makes a
+  2-element symbol *list*. `` `ask,`Prices `` gives `` `ask`Prices `` (a
+  vector), not `` `askPrices``. Trying to dynamically build a lookup key
+  this way (e.g. `` book[side,`Prices] `` to pick `askPrices`/`bidPrices`
+  by a `side` variable) silently returns a null instead of erroring -
+  broke `crossBookAtSizes`'s first draft. Build dynamic symbols from
+  *strings* instead (`` `$(string x),"suffix" ``), or better, avoid
+  dynamic key construction entirely and branch explicitly per case (what
+  `forwards.q`'s `orientedLevels` does).
+- Nested lambdas do **not** close over an enclosing function's *local*
+  variables - only globals. `outer:{[] localVar:42; inner:{[d] localVar+d};
+  inner[8]}` throws `localVar` (undefined), even though `inner` is
+  textually nested inside `outer`. This matters most for qUnit's
+  `assertError`/`assertThrows` pattern: a `wrapper` lambda meant to defer
+  a call for `assertError` to invoke must take everything it needs as an
+  **explicit parameter** (e.g. `{[books] ...books 0...books 1...}` called
+  as `assertError[wrapper;(book1;book2);msg]`), never by referencing a
+  same-function local from inside the nested lambda body. Getting this
+  wrong doesn't silently pass - the whole test function throws and shows
+  up as `error` rather than `pass` in the qUnit summary, which is at
+  least how it gets caught.
+- A local variable named `cols` shadows q's `cols` keyword (table column
+  names) - same failure mode as the earlier `ss`-shadowing gotcha
+  (`assign`/`type` errors with no clear cause). Avoid naming a variable
+  after any q keyword; when in doubt, check `` key `. `` or just pick a
+  more specific name (`wantCols`, not `cols`).
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,15 @@ which dispatches to one of them by convention symbol (`` `act360``,
 `crossRate`/`invertRate` (A/B * B/C = A/C chain), `crossRateSharedBase`
 (divide - two rates sharing a currency on the *same* side, e.g. EURPLN &
 EURUSD -> USDPLN; a 3+-leg cross like AUDPLN from AUDUSD/EURUSD/EURPLN is
-just composing this with `crossRate`), and `crossBook`/`invertBook`/
-`combineOrientedBooks`/`bookCrossed` for building a synthetic top-of-book
-cross rate from two live order books (auto-detects the shared currency and
-orients/inverts each leg as needed).
+just composing this with `crossRate`), `crossBook`/`invertBook`/
+`combineOrientedBooks`/`bookCrossed`/`ccyOrientCross` for building a
+synthetic top-of-book cross rate from two live order books (auto-detects
+the shared currency and orients/inverts each leg as needed), and
+`crossBookAtSizes`/`invertBookDepth` for the depth-aware version: given
+each leg's *multi-level* order book, prices the cross at a list of sizes
+(e.g. `1000000 3000000 5000000`), walking each leg's depth and converting
+the notional hop-by-hop between legs, returning whichever of
+`` `bid`ask`mid `` you ask for as a table (one row per size).
 
 **options.q** - `gkCall`/`gkPut`, `d1`/`d2`, `gkDeltaCall`/`gkDeltaPut`,
 `gkGamma`, `gkVega`, `gkThetaCall`/`gkThetaPut`, `gkRhoCall`/`gkRhoPut`,
@@ -131,7 +136,7 @@ q tests/run_tests.q
 
 This loads every module, loads every `test_*.q` file, runs the full qUnit
 suite, prints a pass/fail summary, and exits non-zero if anything failed -
-safe to wire into CI as-is. As of this writing: **174 tests, all passing**.
+safe to wire into CI as-is. As of this writing: **195 tests, all passing**.
 
 Every function is tested against at least one of: a published textbook
 reference value (e.g. Hull's Black-Scholes worked example for

--- a/src/forwards.q
+++ b/src/forwards.q
@@ -120,6 +120,27 @@ combineOrientedBooks:{[bookAB;bookBC]
 / @eg .uqf.bookCrossed[`bid`ask!(1.1000;1.1002)]  -> 0b
 bookCrossed:{[book] book[`bid]>book[`ask]};
 
+/ Private: work out how two currency pairs relate - which currency they
+/ share, what the resulting cross pair's symbol is, and whether either
+/ leg needs inverting before combining - without touching any prices.
+/ Shared by crossBook and crossBookAtSizes so the two can never disagree
+/ about orientation.
+/ @param sym1 currency pair for leg 1, any format ccy.q's normalizeCcyPair accepts
+/ @param sym2 currency pair for leg 2, any format ccy.q's normalizeCcyPair accepts
+/ @return dict `crossSym`invert1`invert2 - crossSym is the resulting pair
+/   symbol; invert1/invert2 say whether that leg's quote convention needs
+/   flipping (BASE/QUOTE -> QUOTE/BASE) before combining
+/ @throws error if sym1 and sym2 share no common currency
+/ @eg .uqf.ccyOrientCross[`EURUSD;`USDJPY]  -> `crossSym`invert1`invert2!(`EURJPY;0b;0b)
+ccyOrientCross:{[sym1;sym2]
+    legs1:ccyPairLegs sym1; base1:string legs1`base; quote1:string legs1`quote;
+    legs2:ccyPairLegs sym2; base2:string legs2`base; quote2:string legs2`quote;
+    if[quote1~base2; :`crossSym`invert1`invert2!(ccyPairSymbol[base1;quote2];0b;0b)];
+    if[quote1~quote2; :`crossSym`invert1`invert2!(ccyPairSymbol[base1;base2];0b;1b)];
+    if[base1~base2; :`crossSym`invert1`invert2!(ccyPairSymbol[quote1;quote2];1b;0b)];
+    if[base1~quote2; :`crossSym`invert1`invert2!(ccyPairSymbol[quote1;base2];1b;1b)];
+    '"ccyOrientCross: no shared currency between ",base1,quote1," and ",base2,quote2};
+
 / Build a synthetic top-of-book cross rate from two live order books on
 / pairs that share a common currency, e.g. crossBook[`EURUSD;eurusdBook;
 / `USDJPY;usdjpyBook] -> a synthetic EURJPY book. The shared currency is
@@ -127,7 +148,8 @@ bookCrossed:{[book] book[`bid]>book[`ask]};
 / caller does not need to pre-orient anything. sym1/sym2 are normalized
 / via ccy.q's ccyPairLegs, so `eurusd, "eur/usd" etc. work too, not just
 / canonical `EURUSD. Combines top-of-book only; it does not walk/net
-/ multiple depth levels of the underlying books.
+/ multiple depth levels of the underlying books - see crossBookAtSizes
+/ for that.
 / @param sym1 currency pair for book1, any format ccy.q's normalizeCcyPair accepts
 / @param book1 dict `bid`ask!(bidPx;askPx) quoted in sym1's own convention
 / @param sym2 currency pair for book2, any format ccy.q's normalizeCcyPair accepts
@@ -136,24 +158,103 @@ bookCrossed:{[book] book[`bid]>book[`ask]};
 / @throws error if sym1 and sym2 share no common currency
 / @eg .uqf.crossBook[`EURUSD;`bid`ask!(1.1000;1.1002);`USDJPY;`bid`ask!(150.00;150.02)]  -> `sym`bid`ask!(`EURJPY;165;165.052)
 crossBook:{[sym1;book1;sym2;book2]
-    legs1:ccyPairLegs sym1; base1:string legs1`base; quote1:string legs1`quote;
-    legs2:ccyPairLegs sym2; base2:string legs2`base; quote2:string legs2`quote;
-    if[quote1~base2;
-        crossSym:ccyPairSymbol[base1;quote2];
-        combined:combineOrientedBooks[book1;book2];
-        :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
-    if[quote1~quote2;
-        crossSym:ccyPairSymbol[base1;base2];
-        combined:combineOrientedBooks[book1;invertBook book2];
-        :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
-    if[base1~base2;
-        crossSym:ccyPairSymbol[quote1;quote2];
-        combined:combineOrientedBooks[invertBook book1;book2];
-        :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
-    if[base1~quote2;
-        crossSym:ccyPairSymbol[quote1;base2];
-        combined:combineOrientedBooks[invertBook book1;invertBook book2];
-        :`sym`bid`ask!(crossSym;combined`bid;combined`ask)];
-    '"crossBook: no shared currency between ",base1,quote1," and ",base2,quote2};
+    orient:ccyOrientCross[sym1;sym2];
+    oriented1:$[orient`invert1; invertBook book1; book1];
+    oriented2:$[orient`invert2; invertBook book2; book2];
+    combined:combineOrientedBooks[oriented1;oriented2];
+    `sym`bid`ask!(orient`crossSym;combined`bid;combined`ask)};
+
+/ Invert a multi-level depth ladder: BASE/QUOTE -> QUOTE/BASE. Prices
+/ invert elementwise (order stays best-first automatically: inverting a
+/ monotonic ladder reverses its sense exactly the way flipping ask<->bid
+/ requires). Sizes rescale into the new base currency - a level of size
+/ BASE units at price QUOTE/BASE is worth size*price QUOTE units, which
+/ become the new base currency's size.
+/ @param prices level prices, best-first
+/ @param sizes level sizes in the ladder's own base currency, aligned to prices
+/ @return (invertedPrices;rescaledSizes), still best-first
+/ @eg .uqf.invertBookDepth[1.1000 1.1002;1000000 1000000]  -> (0.9090909 0.9089256;1100000 1100200)
+invertBookDepth:{[prices;sizes] (1%prices;sizes*prices)};
+
+/ Private: the (prices;sizes) to sweep for one leg, for one side of the
+/ final cross. If this leg doesn't need inverting, that's just its own
+/ same-named side; if it does, it's the *other* original side, inverted
+/ (an inverted bid becomes an ask, and vice versa).
+/ @param side `bid or `ask - the side of the final cross being priced
+/ @param book dict `bidPrices`bidSizes`askPrices`askSizes for this leg
+/ @param invert 1b if this leg's convention needs flipping
+/ @return (prices;sizes) to pass to sweepPrice
+orientedLevels:{[side;book;invert]
+    $[side=`ask;
+        $[invert; invertBookDepth[book`bidPrices;book`bidSizes]; (book`askPrices;book`askSizes)];
+        $[invert; invertBookDepth[book`askPrices;book`askSizes]; (book`bidPrices;book`bidSizes)]]};
+
+/ Private: sweep one side of a 2-leg cross at one size, converting the
+/ notional hop-by-hop - leg 2 is swept at the amount of the shared/bridge
+/ currency that leg 1's sweep actually produced, not at the raw input size.
+/ @param book1 dict `bidPrices`bidSizes`askPrices`askSizes for leg 1
+/ @param book2 dict `bidPrices`bidSizes`askPrices`askSizes for leg 2
+/ @param side `bid or `ask - the side of the final cross being priced
+/ @param size the size to sweep, in leg 1's relevant currency
+/ @param invert1 1b if leg 1 needs its convention flipped
+/ @param invert2 1b if leg 2 needs its convention flipped
+/ @return dict `price`filledSize`fullyFilled for this side of the cross
+crossSweepSide:{[book1;book2;side;size;invert1;invert2]
+    lvl1:orientedLevels[side;book1;invert1];
+    sweep1:sweepPrice[lvl1 0;lvl1 1;size];
+    bridgeNotional:sweep1[`filledSize]*sweep1[`avgPrice];
+    lvl2:orientedLevels[side;book2;invert2];
+    emptySweep:`avgPrice`worstPrice`filledSize`fullyFilled!(0n;0n;0f;0b);
+    sweep2:$[bridgeNotional>0; sweepPrice[lvl2 0;lvl2 1;bridgeNotional]; emptySweep];
+    price:sweep1[`avgPrice]*sweep2[`avgPrice];
+    fullyFilled:sweep1[`fullyFilled] and sweep2[`fullyFilled];
+    `price`filledSize`fullyFilled!(price;sweep1[`filledSize];fullyFilled)};
+
+/ Private: bid, ask and mid for a 2-leg cross at a single size. mid is the
+/ average of the swept cross bid and the swept cross ask at that size
+/ (not a separate sweep of its own).
+/ @param sym1 currency pair for leg 1
+/ @param book1 dict `bidPrices`bidSizes`askPrices`askSizes for leg 1
+/ @param sym2 currency pair for leg 2
+/ @param book2 dict `bidPrices`bidSizes`askPrices`askSizes for leg 2
+/ @param size the size to sweep, in leg 1's relevant currency
+/ @return one row: dict `size`sym`bid`bidFilledSize`bidFullyFilled`ask`askFilledSize`askFullyFilled`mid
+crossBookAtOneSize:{[sym1;book1;sym2;book2;size]
+    orient:ccyOrientCross[sym1;sym2];
+    bidR:crossSweepSide[book1;book2;`bid;size;orient`invert1;orient`invert2];
+    askR:crossSweepSide[book1;book2;`ask;size;orient`invert1;orient`invert2];
+    midPrice:0.5*bidR[`price]+askR[`price];
+    `size`sym`bid`bidFilledSize`bidFullyFilled`ask`askFilledSize`askFullyFilled`mid!
+      (size;orient`crossSym;bidR`price;bidR`filledSize;bidR`fullyFilled;askR`price;askR`filledSize;askR`fullyFilled;midPrice)};
+
+/ Private: the result columns contributed by one requested side.
+sideCols:{[s]
+    $[s=`bid; `bid`bidFilledSize`bidFullyFilled;
+      s=`ask; `ask`askFilledSize`askFullyFilled;
+      s=`mid; enlist `mid;
+      '"crossBookAtSizes: side must be one of `bid`ask`mid, got ",string s]};
+
+/ Depth-aware synthetic cross rate: like crossBook, but walks multi-level
+/ order book depth on both legs for each requested size, converting the
+/ notional hop-by-hop (leg 2 is swept at the bridge-currency amount leg
+/ 1's sweep actually produced), and returns only the sides you ask for.
+/ Each leg's book must supply real depth, not just top-of-book - see
+/ sweepPrice's book shape.
+/ @param sym1 currency pair for leg 1, any format ccy.q's normalizeCcyPair accepts
+/ @param book1 dict `bidPrices`bidSizes`askPrices`askSizes for leg 1, each level best-first
+/ @param sym2 currency pair for leg 2, any format ccy.q's normalizeCcyPair accepts
+/ @param book2 dict `bidPrices`bidSizes`askPrices`askSizes for leg 2, each level best-first
+/ @param sizes list of sizes to price, e.g. 1000000 2000000 5000000
+/ @param sides subset of `bid`ask`mid to include in the result
+/ @return a table, one row per size, columns `size`sym plus whichever of
+/   bid/bidFilledSize/bidFullyFilled, ask/askFilledSize/askFullyFilled,
+/   mid were requested via sides
+/ @throws error if sym1 and sym2 share no common currency, or sides has
+/   anything other than `bid`ask`mid
+/ @eg .uqf.crossBookAtSizes[`EURUSD;eurusdBook;`USDJPY;usdjpyBook;1000000 3000000;`bid`ask`mid]
+crossBookAtSizes:{[sym1;book1;sym2;book2;sizes;sides]
+    rows:crossBookAtOneSize[sym1;book1;sym2;book2;] each sizes;
+    wantCols:`size`sym , raze sideCols each sides;
+    wantCols#rows};
 
 \d .

--- a/tests/test_forwards.q
+++ b/tests/test_forwards.q
@@ -126,4 +126,110 @@ testCrossBookRejectsNoSharedCurrency:{[t]
     wrapper:{[dummy] .uqf.crossBook[`EURUSD;`bid`ask!(1.10;1.1002);`GBPCHF;`bid`ask!(1.20;1.2003)]};
     .qunit.assertError[wrapper;::;"EURUSD and GBPCHF share no currency"]};
 
+testCcyOrientCrossChain:{[t]
+    r:.uqf.ccyOrientCross[`EURUSD;`USDJPY];
+    .qunit.assertEquals[r`crossSym;`EURJPY;"A/B, B/C -> A/C"];
+    .qunit.assertFalse[r`invert1;"leg1 not inverted"];
+    .qunit.assertFalse[r`invert2;"leg2 not inverted"]};
+
+testCcyOrientCrossSharedQuote:{[t]
+    r:.uqf.ccyOrientCross[`EURUSD;`GBPUSD];
+    .qunit.assertEquals[r`crossSym;`EURGBP;"A/B, C/B -> A/C"];
+    .qunit.assertFalse[r`invert1;"leg1 not inverted"];
+    .qunit.assertTrue[r`invert2;"leg2 inverted (shared quote)"]};
+
+testCcyOrientCrossSharedBase:{[t]
+    r:.uqf.ccyOrientCross[`USDJPY;`USDCHF];
+    .qunit.assertEquals[r`crossSym;`JPYCHF;"B/A, B/C -> A/C"];
+    .qunit.assertTrue[r`invert1;"leg1 inverted (shared base)"];
+    .qunit.assertFalse[r`invert2;"leg2 not inverted"]};
+
+testCcyOrientCrossRejectsNoSharedCurrency:{[t]
+    wrapper:{[dummy] .uqf.ccyOrientCross[`EURUSD;`GBPCHF]};
+    .qunit.assertError[wrapper;::;"no shared currency is rejected"]};
+
+testInvertBookDepthKnown:{[t]
+    r:.uqf.invertBookDepth[1.1000 1.1002;1000000 1000000];
+    .testutil.assertApprox[first r;0.9090909 0.9089256;1e-6;"prices invert elementwise, staying best-first"];
+    .testutil.assertApprox[last r;1100000 1100200;1e-6;"sizes rescale into the new base currency"]};
+
+testInvertBookDepthRoundTrip:{[t]
+    prices:1.2500 1.2503 1.2505;
+    sizes:2000000 1500000 3000000;
+    once:.uqf.invertBookDepth[prices;sizes];
+    twice:.uqf.invertBookDepth[once 0;once 1];
+    .testutil.assertApprox[twice 0;prices;1e-6;"inverting twice restores prices"];
+    .testutil.assertApprox[twice 1;sizes;1e-3;"inverting twice restores sizes"]};
+
+testCrossBookAtSizesMatchesCrossBookAtNegligibleSize:{[t]
+    / a size far smaller than any level's depth should reduce to exactly
+    / crossBook's top-of-book result - a self-consistency check that
+    / needs no hand-computed magic numbers.
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    r:.uqf.crossBookAtSizes[`EURUSD;eurusdBook;`USDJPY;usdjpyBook;enlist 100;`bid`ask];
+    tob:.uqf.crossBook[`EURUSD;`bid`ask!(1.0998;1.1000);`USDJPY;`bid`ask!(149.98;150.00)];
+    .qunit.assertEquals[first r`sym;tob`sym;"cross symbol matches crossBook"];
+    .testutil.assertApprox[first r`bid;tob`bid;1e-6;"negligible-size bid matches crossBook's top-of-book bid"];
+    .testutil.assertApprox[first r`ask;tob`ask;1e-6;"negligible-size ask matches crossBook's top-of-book ask"]};
+
+testCrossBookAtSizesSharedCornerMatchesCrossBookAtNegligibleSize:{[t]
+    / same consistency check, but for the shared-quote (invert) branch
+    audusdBook:`bidPrices`bidSizes`askPrices`askSizes!(0.6498 0.6496;2000000 2000000;0.6500 0.6502;2000000 2000000);
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;2000000 2000000;1.1000 1.1002;2000000 2000000);
+    r:.uqf.crossBookAtSizes[`AUDUSD;audusdBook;`EURUSD;eurusdBook;enlist 100;`bid`ask];
+    tob:.uqf.crossBook[`AUDUSD;`bid`ask!(0.6498;0.6500);`EURUSD;`bid`ask!(1.0998;1.1000)];
+    .qunit.assertEquals[first r`sym;tob`sym;"cross symbol matches crossBook (AUDEUR)"];
+    .testutil.assertApprox[first r`bid;tob`bid;1e-6;"negligible-size bid matches crossBook's top-of-book bid"];
+    .testutil.assertApprox[first r`ask;tob`ask;1e-6;"negligible-size ask matches crossBook's top-of-book ask"]};
+
+testCrossBookAtSizesWalksMultipleLevels:{[t]
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    r:.uqf.crossBookAtSizes[`EURUSD;eurusdBook;`USDJPY;usdjpyBook;enlist 1500000;`bid`ask`mid];
+    .testutil.assertApprox[first r`bid;164.9293;1e-3;"blended bid after walking depth on both legs"];
+    .testutil.assertApprox[first r`ask;165.0187;1e-3;"blended ask after walking depth on both legs"];
+    .testutil.assertApprox[first r`mid;164.974;1e-3;"mid is the average of the swept bid and ask"];
+    .qunit.assertTrue[first r`bidFullyFilled;"enough depth to fully fill 1.5mm"];
+    .qunit.assertTrue[first r`askFullyFilled;"enough depth to fully fill 1.5mm"]};
+
+testCrossBookAtSizesInsufficientDepth:{[t]
+    / total depth per side is 2mm; asking for 3mm can't be fully filled
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    r:.uqf.crossBookAtSizes[`EURUSD;eurusdBook;`USDJPY;usdjpyBook;enlist 3000000;`bid`ask];
+    .testutil.assertApprox[first r`bidFilledSize;2000000f;1e-6;"bid caps at leg1's total depth"];
+    .testutil.assertApprox[first r`askFilledSize;2000000f;1e-6;"ask caps at leg1's total depth"];
+    .qunit.assertFalse[first r`bidFullyFilled;"not fully filled"];
+    .qunit.assertFalse[first r`askFullyFilled;"not fully filled"]};
+
+testCrossBookAtSizesMidVariesWithAsymmetricDepth:{[t]
+    / an asymmetric book (thin ask, deep bid) should make mid genuinely
+    / size-dependent, not coincidentally constant
+    thinAskBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996 1.0994;3000000 3000000 3000000;1.1000 1.1010;200000 5000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    r:.uqf.crossBookAtSizes[`EURUSD;thinAskBook;`USDJPY;usdjpyBook;500000 3000000;enlist `mid];
+    .qunit.assertTrue[(r[`mid] 0)<(r[`mid] 1);"mid increases with size once the thin ask level is exhausted"]};
+
+testCrossBookAtSizesSidesFiltering:{[t]
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    r:.uqf.crossBookAtSizes[`EURUSD;eurusdBook;`USDJPY;usdjpyBook;enlist 1000000;enlist `mid];
+    .qunit.assertEquals[cols r;`size`sym`mid;"requesting just mid returns only size, sym and mid columns"]};
+
+testCrossBookAtSizesRejectsInvalidSide:{[t]
+    / note: wrapper takes the whole (book1;book2) tuple as a single
+    / argument rather than closing over local variables - nested q
+    / lambdas do NOT see an enclosing function's locals, only globals.
+    wrapper:{[books] .uqf.crossBookAtSizes[`EURUSD;books 0;`USDJPY;books 1;enlist 1000000;enlist `close]};
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    usdjpyBook:`bidPrices`bidSizes`askPrices`askSizes!(149.98 149.96;1000000 2000000;150.00 150.02;1000000 2000000);
+    .qunit.assertError[wrapper;(eurusdBook;usdjpyBook);"an unrecognised side symbol is rejected"]};
+
+testCrossBookAtSizesRejectsNoSharedCurrency:{[t]
+    wrapper:{[books] .uqf.crossBookAtSizes[`EURUSD;books 0;`GBPCHF;books 1;enlist 1000000;`bid`ask]};
+    eurusdBook:`bidPrices`bidSizes`askPrices`askSizes!(1.0998 1.0996;1000000 1000000;1.1000 1.1002;1000000 1000000);
+    gbpchfBook:`bidPrices`bidSizes`askPrices`askSizes!(1.20 1.19;1000000 1000000;1.21 1.22;1000000 1000000);
+    .qunit.assertError[wrapper;(eurusdBook;gbpchfBook);"EURUSD and GBPCHF share no currency"]};
+
 \d .


### PR DESCRIPTION
## Summary
- **crossBookAtSizes**: extends `crossBook` with real multi-level order-book depth. Given each leg's book as bid/ask price+size ladders, prices the synthetic cross at a **list of requested sizes** (e.g. `1000000 2000000 5000000`), walking depth via `sweepPrice` and converting the notional **hop-by-hop** between legs (leg 2 is swept at the bridge-currency amount leg 1's sweep actually produced). Returns a table, one row per size, with only the requested `` `bid`ask`mid `` columns.
- **mid is size-dependent**: the average of the swept cross bid and ask *at that size*, not a fixed reference rate - verified with an asymmetric-spread test that mid genuinely moves with size.
- Refactored `crossBook`'s 4-branch orientation detection into a shared `ccyOrientCross`, so `crossBook` and `crossBookAtSizes` can never disagree about which leg needs inverting. `crossBook`'s own behavior is unchanged (still top-of-book only); all its existing tests pass unmodified.
- New `invertBookDepth` primitive: inverts a multi-level depth ladder (prices invert elementwise, sizes rescale into the new base currency).

## Test plan
- [x] Full qUnit suite: 195/195 passing (`q tests/run_tests.q`)
- [x] Self-consistency: `crossBookAtSizes` at negligible size exactly matches `crossBook`'s top-of-book result, for both the direct-chain (EURUSD+USDJPY) and shared-corner/invert (AUDUSD+EURUSD) orientations
- [x] Explicit multi-level depth walking, insufficient-depth propagation, and asymmetric-spread mid-size-dependence cases
- [x] `crossBook` refactor re-verified against all its pre-existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)