### PR TITLE
Parametrize cross_markout/reshape example scripts consistently

### DIFF
--- a/scripts/cross_markout_example.q
+++ b/scripts/cross_markout_example.q
@@ -17,7 +17,9 @@
 // a mid-expression variable assignment/read pattern PeachQ doesn't
 // evaluate correctly (see README's Licensing section).
 //
-// Run from the repository root: q scripts/cross_markout_example.q
+// Run from the repository root: q scripts/cross_markout_example.q [n_ticks]
+// n_ticks (default 6) is how many ticks to generate per leg - optional,
+// positional, same convention as timer_replay_example.q's parameters.
 
 \c 400 1000
 \l src/init.q
@@ -65,8 +67,13 @@ mk_tick_series:{[sym;start_spot;drift_per_tick;ts]
 
 / 6 ticks per leg over roughly a second: AUDUSD and EURPLN drift up,
 / EURUSD drifts down - so a synthetic AUDPLN move should show up as a
-/ genuine multi-leg story, not one leg dominating everything.
-n_ticks:6;
+/ genuine multi-leg story, not one leg dominating everything. Overridable
+/ via the command line (q scripts/cross_markout_example.q [n_ticks]) -
+/ .z.x is the list of args after the script name, always strings; cast
+/ and fall back to the default whenever an arg wasn't given, same
+/ convention as timer_replay_example.q's parameters.
+default_n_ticks:6;
+n_ticks:$[0<count .z.x; "J"$first .z.x; default_n_ticks];
 start_ts:.z.p;
 audusd_ts:mk_timestamps[n_ticks;start_ts];
 eurusd_ts:mk_timestamps[n_ticks;start_ts];

--- a/scripts/reshape_wide_order_book_example.q
+++ b/scripts/reshape_wide_order_book_example.q
@@ -14,7 +14,10 @@
 // a mid-expression variable assignment/read pattern PeachQ doesn't
 // evaluate correctly (see README's Licensing section).
 //
-// Run from the repository root: q scripts/reshape_wide_order_book_example.q
+// Run from the repository root: q scripts/reshape_wide_order_book_example.q [n_rows]
+// n_rows (default 3) is how many rows the wide source table has -
+// optional, positional, same convention as timer_replay_example.q's
+// parameters.
 
 \c 400 1000
 \l src/init.q
@@ -25,7 +28,12 @@
 .log4q.sevl:`DEBUG;
 key[.log4q.snk] set' .log4q.sev .log4q.sevl;
 
-n_rows:3;
+/ Overridable via the command line - .z.x is the list of args after the
+/ script name, always strings; cast and fall back to the default whenever
+/ an arg wasn't given, same convention as timer_replay_example.q's
+/ parameters.
+default_n_rows:3;
+n_rows:$[0<count .z.x; "J"$first .z.x; default_n_rows];
 
 / Illustrative, approximately realistic EURUSD spot rate (not live market
 / data). tick_scale is the price columns' unit relative to the quoted rate
@@ -90,14 +98,23 @@ mk_timestamps:{[n;start_ts]
 ts:mk_timestamps[n_rows;.z.p];
 
 / Identifier columns ingested as strings (type 10h cells) instead of
-/ symbols - the shape symbolize_columns/candidate_symbol_columns exist for.
+/ symbols - the shape symbolize_columns/candidate_symbol_columns exist
+/ for. action/side cycle through a small repeating pattern so rows aren't
+/ all identical, scaling with n_rows the same way
+/ reshape_wide_order_book_multi_pair_example.q's mk_pair_table does (with
+/ n_rows=3, this reproduces the original fixed "A","M","C"/"B","S","B"
+/ exactly).
+action_idx:(til n_rows) mod 3;
+side_idx:(til n_rows) mod 2;
+actions:("A";"M";"C") action_idx;
+sides:("B";"S") side_idx;
 meta_table:flip `ts`sym`venue`exchange`action`side!(
     ts;
-    ("EURUSD";"EURUSD";"EURUSD");
-    ("XCME";"XCME";"XCME");
-    ("GLBX";"GLBX";"GLBX");
-    ("A";"M";"C");
-    ("B";"S";"B"));
+    n_rows#enlist "EURUSD";
+    n_rows#enlist "XCME";
+    n_rows#enlist "GLBX";
+    actions;
+    sides);
 
 t:meta_table,'level_table;
 INFO ("t - wide source table: %1 rows, %2 columns";(count t;count cols t));

--- a/scripts/reshape_wide_order_book_multi_pair_example.q
+++ b/scripts/reshape_wide_order_book_multi_pair_example.q
@@ -14,7 +14,10 @@
 // a mid-expression variable assignment/read pattern PeachQ doesn't
 // evaluate correctly (see README's Licensing section).
 //
-// Run from the repository root: q scripts/reshape_wide_order_book_multi_pair_example.q
+// Run from the repository root: q scripts/reshape_wide_order_book_multi_pair_example.q [rows_per_pair]
+// rows_per_pair (default 20) is how many rows each of the three pairs
+// contributes - optional, positional, same convention as
+// timer_replay_example.q's parameters.
 
 \c 400 1000
 \l src/init.q
@@ -25,7 +28,12 @@
 .log4q.sevl:`DEBUG;
 key[.log4q.snk] set' .log4q.sev .log4q.sevl;
 
-rows_per_pair:20;
+/ Overridable via the command line - .z.x is the list of args after the
+/ script name, always strings; cast and fall back to the default whenever
+/ an arg wasn't given, same convention as timer_replay_example.q's
+/ parameters.
+default_rows_per_pair:20;
+rows_per_pair:$[0<count .z.x; "J"$first .z.x; default_rows_per_pair];
 
 / Illustrative, approximately realistic spot rates (not live market data).
 / tick_scale is the price columns' unit relative to the quoted rate (1 =


### PR DESCRIPTION
## Summary
- Same parametrization mechanism as `timer_replay_example.q`'s `n_ticks`/`tick_ms`, applied consistently: an optional positional command-line arg from `.z.x`, cast via `"J"$` to match the original literal default's type, falling back to that default when not given.
  - `cross_markout_example.q`: `n_ticks` (default 6)
  - `reshape_wide_order_book_example.q`: `n_rows` (default 3)
  - `reshape_wide_order_book_multi_pair_example.q`: `rows_per_pair` (default 20)
- Found and fixed a real bug while parametrizing `reshape_wide_order_book_example.q`: its identifier columns were hardcoded as fixed 3-element tuples, so `n_rows` only ever actually worked at the default of 3 - any other value threw a length error. Fixed by scaling those columns the same way the multi-pair script already did.
- `cross_book_chain_example.q` deliberately left unparametrized - its back half demonstrates specific fixed-timing assertions (three named ticks with hardcoded before/between/after checks), not a scalable amount of data, so it has no natural single count parameter without restructuring what it demonstrates.

## Test plan
- [x] Full qUnit suite unaffected (296/296 on both interpreters)
- [x] All three scripts re-run with default, custom, and edge-case (n=1) parameter values under real KDB-X

🤖 Generated with [Claude Code](https://claude.com/claude-code)