### PR TITLE
Add env/: table schemas for a broader trading system

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ scripts/
                             `yes "" | q scripts/timer_replay_example.q`
                             (see the script's own header for why)
 
+env/
+  schemas.q   10 empty, typed table schemas for a broader trading system
+              (market_data, positions, predictions, orders, trades,
+              markouts, reference_data, order_routing, connections,
+              economic_calendar) - scaffolding/reference, not part of the
+              uqf pricing library itself; see env/README.md
+  seed.q      populates every env/schemas.q table with a small, coherent
+              example scenario
+
 .claude/skills/kdb-q-conventions/   q-language conventions for this repo,
                                      including the operator-precedence gotcha
                                      below (loaded automatically by Claude

--- a/env/README.md
+++ b/env/README.md
@@ -1,0 +1,53 @@
+# env/
+
+Empty, typed table schemas for a broader eFX trading system's data model,
+plus a script that seeds them with a small, coherent example scenario.
+
+**This is scaffolding/reference material, not part of the `uqf` pricing
+library.** `uqf` itself stays strictly scoped to eFX pricing, risk, and
+execution *functions* (see the `kdb-q-conventions` skill's scope note) -
+it has no positions, orders, connections, or any other stateful,
+system-level concept of its own. `env/` exists alongside that library for
+whoever wants a starting data model for the rest of a trading system uqf's
+functions would sit inside, without uqf itself taking a position on how
+that system is built.
+
+Deliberately kept separate from `src/*.q` and its per-module `.q<abbrev>`
+namespace convention (`.qstats`, `.qfwd`, `.qexec`, ...) - everything here
+lives in its own single `.envschema` namespace instead, and neither file is
+loaded by `src/init.q`.
+
+## Files
+
+- **`schemas.q`** - the 10 empty table definitions, one `\d .envschema` block.
+  Not loaded by `src/init.q`; `\l env/schemas.q` on its own works under
+  either interpreter (PeachQ or real KDB-X) with no other dependency.
+- **`seed.q`** - loads `src/init.q` + `schemas.q` + `lib/log4q.q`, then
+  populates every table with a few example rows that reference each other
+  (same `order_id`/`trade_id`/`sym`/venue) so the result reads as one small
+  realistic scenario, not ten unrelated tables. Requires real kdb+/KDB-X,
+  not the local PeachQ binary, for the same log4q reason every
+  `scripts/*.q` example does (see README's Licensing section). Run from
+  the repository root: `q env/seed.q`.
+
+## Tables
+
+| Table | Shape notes |
+|---|---|
+| `market_data` | Identical to `forwards.q`'s `quotes` shape (`require_quotes_cols`/`cross_book_at`) - level-0-first vector columns, one row per (ts, sym) snapshot. |
+| `positions` | One row per (account, sym) snapshot; `side`/`notional`/`avg_entry_rate` follow `risk.q`'s own `pnl`/`carry_pnl` naming and `1`/`-1` side convention. |
+| `predictions` | One row per (ts, sym, horizon_ms, model); `horizon_ms` matches `cross_markout_at_horizons`' horizon convention. |
+| `orders` | One row per order, updated in place as `status` changes (`new`/`filled`/`cancelled`/`rejected`). |
+| `trades` | `sym`/`time`/`side`/`trade_price`/`pip_factor` are exactly `execution.q`'s `markout_at_horizons` input shape - select those five columns straight off this table and pass it in directly, no reshaping. |
+| `markouts` | Exactly `markout_at_horizons`'s output shape (`ts`/`sym` leading, per its `col_precedence` convention). |
+| `reference_data` | One row per pair; `base_ccy`/`quote_ccy` match `ccy.q`'s `ccy_pair_legs` field names. |
+| `order_routing` | One row per (order, venue) an order was routed to - not 1:1 with `orders`, since an order can split across venues. |
+| `connections` | Venue/process connection registry - up/down status, a much simpler stand-in for what `lib/torq/code/handlers/trackservers.q` does at production scale. |
+| `economic_calendar` | One row per scheduled macro release; `actual` is null until the event fires. |
+
+## Extending
+
+Add a new table the same way: one more line in `schemas.q`'s `.envschema`
+block (empty, explicitly typed, a short comment above it explaining the
+shape and any column it deliberately mirrors elsewhere in the repo), then
+a matching seed block in `seed.q` if you want it populated by default.

--- a/env/schemas.q
+++ b/env/schemas.q
@@ -1,0 +1,76 @@
+/ schemas.q - empty, typed table schemas for a broader eFX trading
+/ system's data model: market data, positions, predictions, orders,
+/ trades, markouts, reference data, order routing, connections, and an
+/ economic calendar.
+/ .
+/ Deliberately separate from src/*.q and its per-module .q<abbrev>
+/ namespace convention (.qstats, .qfwd, .qexec, ...) - this is scaffolding/
+/ reference material for a broader system uqf's own pricing/risk/
+/ execution functions could sit inside, not part of the pure-function
+/ library itself (see kdb-q-conventions' scope note: uqf stays strictly
+/ scoped to eFX pricing/risk/execution). Not loaded by src/init.q.
+/ .
+/ Where a table's shape already matches an existing src/*.q convention,
+/ it's kept identical on purpose rather than reinvented - market_data
+/ matches forwards.q's require_quotes_cols quotes shape exactly; trades
+/ matches execution.q's markout_at_horizons input shape (sym/time/side/
+/ trade_price/pip_factor) so .envschema.trades is directly usable there
+/ with no reshaping; markouts matches that same function's output shape.
+/ Still single-level/flat (not nested under a shared parent) for the
+/ same PeachQ multi-level \d portability reason every src/*.q file is.
+/ .
+/ See env/seed.q to populate these with example rows, and env/README.md
+/ for the full table-by-table rationale.
+
+\d .envschema
+
+/ Order-book snapshots, one row per (ts, sym) - identical shape to
+/ forwards.q's quotes table (require_quotes_cols/cross_book_at). Levels
+/ are level-0-first vectors, one per row (bid_prices/bid_sizes/
+/ ask_prices/ask_sizes).
+market_data:0#([] ts:`timestamp$(); sym:`symbol$(); bid_prices:(); bid_sizes:(); ask_prices:(); ask_sizes:());
+
+/ Position-manager snapshots, one row per (account, sym) at a point in
+/ time. side/notional/avg_entry_rate/unrealized_pnl follow risk.q's own
+/ pnl/carry_pnl parameter naming and 1/-1 side convention.
+positions:0#([] ts:`timestamp$(); account:`symbol$(); sym:`symbol$(); side:`long$(); notional:`float$(); avg_entry_rate:`float$(); mark_rate:`float$(); unrealized_pnl:`float$(); realized_pnl:`float$());
+
+/ Model/signal predictions, one row per (ts, sym, horizon_ms, model).
+/ horizon_ms matches cross_markout_at_horizons' horizon_ms convention -
+/ a prediction for the mid at ts+horizon_ms.
+predictions:0#([] ts:`timestamp$(); sym:`symbol$(); horizon_ms:`long$(); model:`symbol$(); predicted_mid:`float$(); confidence:`float$());
+
+/ Order lifecycle, one row per order, updated in place as status changes
+/ (new -> filled/cancelled/rejected). price is null for market orders.
+orders:0#([] order_id:`long$(); ts:`timestamp$(); sym:`symbol$(); side:`long$(); order_type:`symbol$(); price:`float$(); size:`float$(); status:`symbol$());
+
+/ Executed trades, one row per fill. sym/time/side/trade_price/pip_factor
+/ are exactly execution.q's markout_at_horizons trades-table shape -
+/ .envschema.trades can be passed there directly, no reshaping needed;
+/ trade_id/order_id/size extend it into a standalone trades table.
+trades:0#([] trade_id:`long$(); order_id:`long$(); time:`timestamp$(); sym:`symbol$(); side:`long$(); trade_price:`float$(); size:`float$(); pip_factor:`long$());
+
+/ Markout results, one row per (trade, horizon) - exactly
+/ execution.q's markout_at_horizons output shape (ts/sym leading per its
+/ col_precedence convention).
+markouts:0#([] ts:`timestamp$(); sym:`symbol$(); trade_time:`timestamp$(); horizon:`timespan$(); trade_price:`float$(); ref_price:`float$(); markout_pips:`float$());
+
+/ Static instrument reference, one row per pair. base_ccy/quote_ccy match
+/ ccy.q's ccy_pair_legs field names.
+reference_data:0#([] sym:`symbol$(); base_ccy:`symbol$(); quote_ccy:`symbol$(); pip_factor:`long$(); min_size:`float$(); active:`boolean$());
+
+/ Routing decisions, one row per (order, venue) an order was routed to
+/ (an order can split across venues, hence not 1:1 with orders).
+order_routing:0#([] order_id:`long$(); ts:`timestamp$(); venue:`symbol$(); routed_size:`float$(); routing_reason:`symbol$());
+
+/ Venue/process connection registry - one row per connection, tracking
+/ up/down status the way TorQ's process tracking does (see
+/ lib/torq/code/handlers/trackservers.q for the reference this is
+/ deliberately a much simpler stand-in for).
+connections:0#([] venue:`symbol$(); host:`symbol$(); port:`long$(); status:`symbol$(); last_heartbeat:`timestamp$());
+
+/ Scheduled macro/economic releases, one row per event. forecast/previous
+/ are known ahead of the release; actual is null until the event fires.
+economic_calendar:0#([] event_id:`long$(); ts:`timestamp$(); ccy:`symbol$(); event_name:`symbol$(); importance:`symbol$(); forecast:`float$(); previous:`float$(); actual:`float$());
+
+\d .

--- a/env/seed.q
+++ b/env/seed.q
@@ -1,0 +1,107 @@
+// seed.q - populates env/schemas.q's empty tables with a small, coherent
+// set of example rows: a EURUSD position, a prediction for it, the order
+// and trade that opened it, the resulting markout, reference data for the
+// pairs involved, where the order was routed, the venue connection it
+// routed through, and an economic event around the pair's currencies.
+// Not a random assortment - the rows reference each other (same order_id,
+// trade_id, sym) so this reads as one small, realistic scenario rather
+// than ten unrelated tables.
+//
+// Reuses uqf's own conventions/helpers throughout (loads src/init.q) -
+// .qccy.ccy_pair_legs for reference_data's base/quote split,
+// .qrisk.pnl for the position's unrealized P&L, and a real call through
+// .qexec.markout_at_horizons for the markouts row (not a hand-typed
+// fake result) - env/schemas.q's trades shape is exactly that
+// function's expected input, so no reshaping is needed to call it.
+//
+// Narration/status uses lib/log4q.q's INFO/DEBUG (see README's Licensing
+// section) - requires real kdb+/KDB-X, not the local PeachQ binary, for
+// the same reason every other scripts/*.q example does.
+//
+// Run from the repository root: q env/seed.q
+
+\c 400 1000
+\l src/init.q
+\l env/schemas.q
+\l lib/log4q.q
+
+.log4q.sevl:`DEBUG;
+key[.log4q.snk] set' .log4q.sev .log4q.sevl;
+
+t0:2026.08.21D09:00:00.000000000;
+
+/ ==== reference_data: the pairs the rest of this scenario touches ====
+pairs:`EURUSD`AUDUSD`EURPLN;
+DEBUG "running: .qccy.ccy_pair_legs each pairs";
+legs:.qccy.ccy_pair_legs each pairs;
+.envschema.reference_data,:([]
+    sym:pairs;
+    base_ccy:legs`base;
+    quote_ccy:legs`quote;
+    pip_factor:10000 10000 10000;
+    min_size:100000 100000 100000f;
+    active:111b);
+INFO ("reference_data - %1 pairs seeded";count .envschema.reference_data);
+
+/ ==== market_data: a two-pair order-book snapshot ====
+/ Same shape/scaling as the other example scripts' mk_book -
+/ .qex.pip_size/.qex.size_unit (src/example_defaults.q).
+mk_book_row:{[spot]
+    levels:til 3;
+    `bid_prices`bid_sizes`ask_prices`ask_sizes!(
+        spot-.qex.pip_size*levels;.qex.size_unit*1+levels;
+        (spot+.qex.pip_size)+.qex.pip_size*levels;.qex.size_unit*1+levels)};
+.envschema.market_data,:([] ts:2#t0; sym:`EURUSD`AUDUSD),'(mk_book_row each 1.0850 0.6550);
+INFO ("market_data - %1 rows seeded";count .envschema.market_data);
+
+/ ==== orders + trades: one EURUSD buy, filled in full ====
+.envschema.orders,:([] order_id:enlist 1; ts:enlist t0; sym:enlist `EURUSD; side:enlist 1; order_type:enlist `limit; price:enlist 1.0850; size:enlist 1000000f; status:enlist `filled);
+.envschema.trades,:([] trade_id:enlist 1; order_id:enlist 1; time:enlist t0; sym:enlist `EURUSD; side:enlist 1; trade_price:enlist 1.0850; size:enlist 1000000f; pip_factor:enlist 10000);
+INFO ("orders/trades - order 1 (EURUSD buy, 1mm @ 1.0850) filled as trade 1");
+
+/ ==== markouts: a real call through .qexec.markout_at_horizons ====
+/ env/schemas.q's trades shape (sym/time/side/trade_price/pip_factor) is
+/ exactly what that function expects - select straight off .envschema.trades,
+/ no reshaping. The quotes side needs execution.q's simpler sym/time/mid
+/ shape (distinct from market_data's full book shape, which is what
+/ forwards.q's cross_book_at/cross_markout_at_horizons consume instead) -
+/ a few EURUSD mid ticks after the trade, drifting up.
+mo_quotes:([] sym:5#`EURUSD; time:t0+0D 0D00:00:00.100 0D00:00:00.300 0D00:00:00.500 0D00:00:01; mid:1.0850 1.08505 1.08508 1.08512 1.08515);
+trades_for_markout:`sym`time`side`trade_price`pip_factor#.envschema.trades;
+DEBUG "running: .qexec.markout_at_horizons[trades_for_markout;mo_quotes;0D00:00:00.100 0D00:00:00.500]";
+.envschema.markouts,:.qexec.markout_at_horizons[trades_for_markout;mo_quotes;0D00:00:00.100 0D00:00:00.500];
+INFO ("markouts - %1 horizon(s) computed for trade 1";count .envschema.markouts);
+
+/ ==== positions: the resulting open position, marked to a later rate ====
+mark_rate:1.0855;
+DEBUG "running: .qrisk.pnl[1000000;1.0850;mark_rate;1]";
+unrealized:.qrisk.pnl[1000000;1.0850;mark_rate;1];
+.envschema.positions,:([] ts:enlist t0+0D00:00:01; account:enlist `desk1; sym:enlist `EURUSD; side:enlist 1; notional:enlist 1000000f; avg_entry_rate:enlist 1.0850; mark_rate:enlist mark_rate; unrealized_pnl:enlist unrealized; realized_pnl:enlist 0f);
+INFO ("positions - EURUSD position marked, unrealized P&L %1";first .envschema.positions`unrealized_pnl);
+
+/ ==== predictions: a signal that motivated the trade above ====
+.envschema.predictions,:([] ts:enlist t0-0D00:00:00.500; sym:enlist `EURUSD; horizon_ms:enlist 500; model:enlist `momentum_v1; predicted_mid:enlist 1.08508; confidence:enlist 0.62);
+INFO "predictions - one momentum_v1 signal seeded ahead of the trade";
+
+/ ==== order_routing + connections: where order 1 actually went ====
+.envschema.order_routing,:([] order_id:enlist 1; ts:enlist t0; venue:enlist `LP1; routed_size:enlist 1000000f; routing_reason:enlist `best_price);
+.envschema.connections,:([] venue:enlist `LP1; host:enlist `lp1.example.internal; port:enlist 443; status:enlist `connected; last_heartbeat:enlist t0);
+INFO "order_routing/connections - order 1 routed to LP1, connection live";
+
+/ ==== economic_calendar: context for why EURUSD was moving ====
+.envschema.economic_calendar,:([] event_id:enlist 1; ts:enlist t0+0D01; ccy:enlist `EUR; event_name:enlist `ECB_Rate_Decision; importance:enlist `high; forecast:enlist 4.25; previous:enlist 4.25; actual:enlist 0n);
+INFO "economic_calendar - one upcoming high-importance EUR event seeded";
+
+INFO "seed complete - showing every populated table";
+show .envschema.reference_data;
+show .envschema.market_data;
+show .envschema.orders;
+show .envschema.trades;
+show .envschema.markouts;
+show .envschema.positions;
+show .envschema.predictions;
+show .envschema.order_routing;
+show .envschema.connections;
+show .envschema.economic_calendar;
+
+// exit 0


### PR DESCRIPTION
## Summary
New top-level `env/` directory, deliberately separate from `src/*.q` and its per-module namespace convention - scaffolding/reference material for a broader eFX trading system, not a scope expansion of the pure-function pricing library itself.

- `env/schemas.q`: 10 empty, typed table schemas under one `.envschema` namespace - `market_data`, `positions`, `predictions`, `orders`, `trades`, `markouts`, `reference_data`, `order_routing`, `connections`, `economic_calendar`. Reuses existing uqf shapes exactly where they already overlap (`market_data` matches `forwards.q`'s `quotes` shape; `trades` matches `execution.q`'s `markout_at_horizons` input shape so it's directly usable there with no reshaping; `markouts` matches that function's output shape).
- `env/seed.q`: populates every table with a small, coherent example scenario (one order → fill → position/markout/routing/connection/prediction, all sharing the same `order_id`/`trade_id`/`sym`) via a real call through `.qexec.markout_at_horizons`, not a hand-typed fake result.

## Test plan
- [x] Full qUnit suite unaffected (296/296 on both interpreters)
- [x] `schemas.q` loads standalone under both PeachQ and real KDB-X
- [x] `seed.q` runs end-to-end under real KDB-X, all 10 tables populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)