### PR TITLE
Add scripts/torq_demo.sh to bridge lib/torq + lib/torq-finance-starter-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ tests/
 scripts/
   gen-docs.sh   regenerates docs/ via qDoc (see Documentation)
   run_qdoc.sh   alternative: serves browsable docs live via lib/q-doc/ (see Documentation)
+  torq_demo.sh  bridges lib/torq + lib/torq-finance-starter-pack into a
+                runnable demo (start/stop/summary) - see docs/torq-demo.md
   timer_replay_example.q   replays pre-generated synthetic ticks into a
                             live, growing quotes table on a system timer
                             (.z.ts), reacting after each row, instead of
@@ -358,4 +360,7 @@ two vendored files:
   manage, so nothing in `src/*.q` calls into it - vendored for reference
   only, at the repo owner's explicit choice. `env/`'s own table schemas
   cover some of the same shapes (quotes/trades) at a much lighter weight,
-  without the process/feed-handler layer this pulls in.
+  without the process/feed-handler layer this pulls in. It can still be
+  started up and queried, though - `scripts/torq_demo.sh` bridges it with
+  `lib/torq` (see docs/torq-demo.md) so the two vendored trees can run as
+  one demo without either being modified.

--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -1,0 +1,112 @@
+# Running the TorQ Finance Starter Pack demo
+
+`lib/torq/` (the TorQ production framework) and `lib/torq-finance-starter-pack/`
+(a layered reference application built on top of it - feed handlers,
+tickerplant, RDB, an HDB seeded with two days of sample quote/trade data,
+gateway) are both vendored into this repo for reference (see the README's
+Licensing section) but neither is wired into `src/init.q` or anything else
+uqf itself runs - this library has no long-running processes for TorQ's
+machinery to manage.
+
+`scripts/torq_demo.sh` bridges the two vendored trees so you can actually
+start the demo up and poke at it, without editing or writing into either
+`lib/` directory.
+
+## Quick start
+
+```
+scripts/torq_demo.sh start all      # start every startwithall=1 process
+scripts/torq_demo.sh summary        # one-line-per-process status table
+scripts/torq_demo.sh stop all       # stop everything
+```
+
+Run from anywhere - the script resolves its own location and works out
+`lib/torq`/`lib/torq-finance-starter-pack`'s absolute paths itself. First
+`start` bootstraps a data directory at `scripts/output/torq-demo/` (already
+gitignored, matching `scripts/output/`'s existing use for
+`timer_replay_example.q`'s run artifacts) by copying the app's sample
+`hdb/`/`dqe/` data there - `logs/`, `tplogs/`, `wdbhdb/`, and every process's
+actual read/write activity all happen inside that directory, never inside
+`lib/`. Run `scripts/torq_demo.sh clean` to wipe it and start fresh next
+time.
+
+Requires real kdb+/KDB-X (`q` on `PATH`) - not the PeachQ binary used
+elsewhere in this repo for `src/`/`tests/` - plus `envsubst` and `rlwrap`
+(TorQ's own `torq.sh` needs both; on macOS: `brew install gettext rlwrap`).
+
+## What actually starts
+
+By default (`start all`) only the 13 processes marked `startwithall=1` in
+`lib/torq-finance-starter-pack/appconfig/process.csv` come up - the vendored
+README explains why: the KDB-X community edition's connection limits mean
+`monitor1`, `reporter1`, `filealerter1`, `dqc1`/`dqcdb1`, `dqe1`/`dqedb1`
+stay off unless you have a fully-licensed kdb+/KDB-X. `killtick` and
+`tpreplay1` are on-demand utility processes, not part of the standing
+stack, so they also don't auto-start.
+
+Default ports (base `6000`, override with `TORQ_DEMO_PORT=<n>
+scripts/torq_demo.sh start all`):
+
+| Port | Process | Role |
+|---|---|---|
+| 6000 | stp1 | segmented tickerplant |
+| 6001 | discovery1 | service discovery |
+| 6002 | rdb1 | real-time DB (today's ticks) |
+| 6003 / 6004 | hdb1 / hdb2 | historical DB (the vendored sample data) |
+| 6005 | wdb1 | writedown process (rolls RDB -> HDB) |
+| 6006 | sort1 | sorts data before writedown |
+| 6007 | gateway1 | single query entry point across hdb/rdb |
+| 6011 | housekeeping1 | log/process housekeeping |
+| 6014 | feed1 | the dummy feed generating simulated quotes/trades |
+| 6015 | sctp1 | segmented chained tickerplant |
+| 6016 / 6017 | sortworker1/2 | sort worker pool |
+| 6018 | metrics1 | metrics collector |
+
+## Connecting
+
+Every process (except the passwordless `feed1`) is protected by
+`lib/torq-finance-starter-pack/appconfig/passwords/accesslist.txt` -
+placeholder demo credentials, `admin:admin` works for everything. From any
+q session:
+
+```
+q)h:hopen `:localhost:6002:admin:admin        / rdb1 - today's live ticks
+q)h "select count i by sym from quote"
+q)hclose h
+```
+
+The gateway (6007) is the intended single entry point for querying across
+the RDB and HDB together rather than connecting to each directly - see
+`lib/torq-finance-starter-pack/docs/gettingstarted.md` and
+`lib/torq/code/processes/gateway.q` for its `.gw.execute` API; this repo
+doesn't wrap or simplify it further.
+
+## Verifying it's alive
+
+```
+scripts/torq_demo.sh summary
+```
+
+prints a status table (`up`/`down`, pid, port) for every process defined in
+`process.csv`, not just the ones `start all` brought up. Per-process stdout/
+stderr logs land in `scripts/output/torq-demo/logs/` (`out_<procname>.log` /
+`err_<procname>.log`) - check these first if a process shows `down`
+unexpectedly.
+
+## Other commands
+
+`scripts/torq_demo.sh` is a thin wrapper - everything after the first
+argument passes straight through to `lib/torq/torq.sh`, whose own `usage`
+output (run the wrapper with no arguments) lists the rest: `stop
+<processname(s)>` / `restart` for a subset instead of `all`, `print all` to
+see the exact startup command lines without starting anything, `debug
+<processname>` to run one process in the foreground for troubleshooting,
+`top <processname>`, and `qcon <processname> admin:admin` to open an
+interactive console (requires `qcon` on `PATH`, not installed by default -
+`hopen` from a q session, as above, works without it).
+
+## Known harmless warnings
+
+`hostname -I`/`hostname -A` (Linux-only flags `torq.sh` calls unconditionally
+at startup) print `illegal option` warnings on macOS's BSD `hostname` - safe
+to ignore, they don't affect anything the demo actually uses.

--- a/scripts/torq_demo.sh
+++ b/scripts/torq_demo.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# torq_demo.sh - bridges lib/torq (the vendored TorQ framework) and
+# lib/torq-finance-starter-pack (the vendored app built on top of it) into
+# one runnable demo, without touching either vendored tree.
+#
+# TorQ's own convention (see lib/torq/installtorqapp.sh) is to point a set
+# of env vars - TORQHOME at the framework, TORQAPPHOME at the app, plus a
+# writable data root - at whichever directories you like; appconfig/
+# process.csv already references KDBCODE/KDBAPPCODE/KDBHDB/etc as
+# ${VAR}-style placeholders (see torq.sh's use of envsubst), so no physical
+# merge of the two lib/ trees is needed. This script just sets those vars
+# to point at uqf's two lib/ dirs, points every writable path (logs,
+# tickerplant logs, wdb, and a copy of the sample hdb/dqe data) at a
+# gitignored scripts/output/torq-demo/ directory instead of into lib/, and
+# execs lib/torq/torq.sh with whatever arguments you passed in.
+#
+# Usage (from anywhere - resolves its own location):
+#   scripts/torq_demo.sh start all      # start every startwithall=1 process
+#   scripts/torq_demo.sh summary        # one-line-per-process status table
+#   scripts/torq_demo.sh stop all       # stop everything
+#   scripts/torq_demo.sh clean          # wipe scripts/output/torq-demo/
+#
+# See docs/torq-demo.md for the full writeup (ports, monitor UI, qcon,
+# troubleshooting, the community-edition process limits this pack already
+# works around).
+
+set -euo pipefail
+
+if [ "-bash" = "$0" ]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+fi
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+export TORQHOME="$repo_root/lib/torq"
+export TORQAPPHOME="$repo_root/lib/torq-finance-starter-pack"
+torq_data="$repo_root/scripts/output/torq-demo"
+
+if [ ! -d "$TORQHOME" ] || [ ! -f "$TORQHOME/torq.q" ]; then
+  echo "ERROR: $TORQHOME not found or missing torq.q - is lib/torq vendored?" >&2
+  exit 1
+fi
+if [ ! -d "$TORQAPPHOME" ] || [ ! -f "$TORQAPPHOME/database.q" ]; then
+  echo "ERROR: $TORQAPPHOME not found or missing database.q - is lib/torq-finance-starter-pack vendored?" >&2
+  exit 1
+fi
+
+for tool in envsubst rlwrap; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: '$tool' not found on PATH - torq.sh needs it (macOS: brew install gettext rlwrap)" >&2
+    exit 1
+  fi
+done
+
+if [ "${1:-}" = "clean" ]; then
+  echo "Removing $torq_data"
+  rm -rf "$torq_data"
+  exit 0
+fi
+
+# Bootstrap the writable data dir on first run: copy (never symlink - these
+# processes write into hdb/wdb/tplogs) the app's sample hdb/dqe data once,
+# so nothing ever gets written into the vendored lib/ tree.
+if [ ! -d "$torq_data/hdb" ]; then
+  echo "Bootstrapping $torq_data (first run) - copying sample hdb/dqe data..."
+  mkdir -p "$torq_data"
+  cp -R "$TORQAPPHOME/hdb" "$torq_data/hdb"
+  cp -R "$TORQAPPHOME/dqe" "$torq_data/dqe"
+fi
+mkdir -p "$torq_data/logs" "$torq_data/tplogs" "$torq_data/wdbhdb"
+
+kdb_base_port="${TORQ_DEMO_PORT:-6000}"
+
+# torq.sh unconditionally sources $SETENV (defaulting to lib/torq/setenv.sh,
+# which would overwrite TORQAPPHOME/TORQPROCESSES/etc back to lib/torq's own
+# defaults) - so generate our own setenv.sh into the gitignored data dir,
+# pointing everything at uqf's two lib/ trees plus this data dir, and point
+# SETENV at it instead.
+generated_setenv="$torq_data/setenv.sh"
+cat >"$generated_setenv" <<EOF
+export TORQHOME="$TORQHOME"
+export TORQAPPHOME="$TORQAPPHOME"
+export TORQDATA="$torq_data"
+export KDBCONFIG="$TORQHOME/config"
+export KDBCODE="$TORQHOME/code"
+export KDBAPPCONFIG="$TORQAPPHOME/appconfig"
+export KDBAPPCODE="$TORQAPPHOME/code"
+export KDBLIB="$TORQHOME/lib"
+export KDBTESTS="$TORQHOME/tests"
+export KDBLOG="$torq_data/logs"
+export KDBHDB="$torq_data/hdb"
+export KDBWDB="$torq_data/wdbhdb"
+export KDBTPLOG="$torq_data/tplogs"
+export KDBDQCDB="$torq_data/dqe/dqcdb/database"
+export KDBDQEDB="$torq_data/dqe/dqedb/database"
+export KDBBASEPORT="$kdb_base_port"
+export KDBSTACKID="-stackid \${KDBBASEPORT}"
+export TORQPROCESSES="$TORQAPPHOME/appconfig/process.csv"
+export RLWRAP="rlwrap"
+export QCON="qcon"
+export QCMD="q"
+EOF
+
+export SETENV="$generated_setenv"
+
+if [ $# -eq 0 ]; then
+  echo "torq_demo.sh - bridges lib/torq + lib/torq-finance-starter-pack (see docs/torq-demo.md)"
+  echo
+fi
+
+exec "$TORQHOME/torq.sh" "$@"


### PR DESCRIPTION
## Summary
- Adds `scripts/torq_demo.sh`, a thin wrapper that runs the vendored TorQ-Finance-Starter-Pack demo by pointing TorQ's own env-var-driven conventions (`TORQHOME`/`TORQAPPHOME`/`KDBCODE`/`KDBAPPCODE`/etc) at `lib/torq` and `lib/torq-finance-starter-pack` - no physical merge of the two vendored trees, and neither is ever modified.
- All writable state (logs, tplogs, wdb, a copy of the sample hdb/dqe data) lives under gitignored `scripts/output/torq-demo/`, bootstrapped on first `start`.
- Adds `docs/torq-demo.md`: usage, default ports, connecting via `hopen`, and the community-edition process limits already documented in the vendored pack's own README.
- Points to both from the root `README.md`.

## Test plan
- [x] `./q tests/run_tests.q` passes (296/296, PeachQ)
- [x] `scripts/torq_demo.sh start all` brings up all 13 `startwithall=1` processes (verified via `summary`)
- [x] Live query against `rdb1` confirms `feed1`'s simulated ticks are actually flowing
- [x] `scripts/torq_demo.sh stop all` shuts everything down cleanly, no leftover processes
- [x] Confirmed `scripts/output/torq-demo/` stays untracked (existing `/scripts/output/` gitignore rule covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)