### PR TITLE
Shift torq_demo.sh default base port from 6000 to 6010

### DIFF
--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -44,23 +44,23 @@ stay off unless you have a fully-licensed kdb+/KDB-X. `killtick` and
 `tpreplay1` are on-demand utility processes, not part of the standing
 stack, so they also don't auto-start.
 
-Default ports (base `6000`, override with `TORQ_DEMO_PORT=<n>
+Default ports (base `6010`, override with `TORQ_DEMO_PORT=<n>
 scripts/torq_demo.sh start all`):
 
 | Port | Process | Role |
 |---|---|---|
-| 6000 | stp1 | segmented tickerplant |
-| 6001 | discovery1 | service discovery |
-| 6002 | rdb1 | real-time DB (today's ticks) |
-| 6003 / 6004 | hdb1 / hdb2 | historical DB (the vendored sample data) |
-| 6005 | wdb1 | writedown process (rolls RDB -> HDB) |
-| 6006 | sort1 | sorts data before writedown |
-| 6007 | gateway1 | single query entry point across hdb/rdb |
-| 6011 | housekeeping1 | log/process housekeeping |
-| 6014 | feed1 | the dummy feed generating simulated quotes/trades |
-| 6015 | sctp1 | segmented chained tickerplant |
-| 6016 / 6017 | sortworker1/2 | sort worker pool |
-| 6018 | metrics1 | metrics collector |
+| 6010 | stp1 | segmented tickerplant |
+| 6011 | discovery1 | service discovery |
+| 6012 | rdb1 | real-time DB (today's ticks) |
+| 6013 / 6014 | hdb1 / hdb2 | historical DB (the vendored sample data) |
+| 6015 | wdb1 | writedown process (rolls RDB -> HDB) |
+| 6016 | sort1 | sorts data before writedown |
+| 6017 | gateway1 | single query entry point across hdb/rdb |
+| 6021 | housekeeping1 | log/process housekeeping |
+| 6024 | feed1 | the dummy feed generating simulated quotes/trades |
+| 6025 | sctp1 | segmented chained tickerplant |
+| 6026 / 6027 | sortworker1/2 | sort worker pool |
+| 6028 | metrics1 | metrics collector |
 
 ## Connecting
 
@@ -70,12 +70,12 @@ placeholder demo credentials, `admin:admin` works for everything. From any
 q session:
 
 ```
-q)h:hopen `:localhost:6002:admin:admin        / rdb1 - today's live ticks
+q)h:hopen `:localhost:6012:admin:admin        / rdb1 - today's live ticks
 q)h "select count i by sym from quote"
 q)hclose h
 ```
 
-The gateway (6007) is the intended single entry point for querying across
+The gateway (6017) is the intended single entry point for querying across
 the RDB and HDB together rather than connecting to each directly - see
 `lib/torq-finance-starter-pack/docs/gettingstarted.md` and
 `lib/torq/code/processes/gateway.q` for its `.gw.execute` API; this repo

--- a/scripts/torq_demo.sh
+++ b/scripts/torq_demo.sh
@@ -70,7 +70,7 @@ if [ ! -d "$torq_data/hdb" ]; then
 fi
 mkdir -p "$torq_data/logs" "$torq_data/tplogs" "$torq_data/wdbhdb"
 
-kdb_base_port="${TORQ_DEMO_PORT:-6000}"
+kdb_base_port="${TORQ_DEMO_PORT:-6010}"
 
 # torq.sh unconditionally sources $SETENV (defaulting to lib/torq/setenv.sh,
 # which would overwrite TORQAPPHOME/TORQPROCESSES/etc back to lib/torq's own


### PR DESCRIPTION
## Summary
- Bumps `scripts/torq_demo.sh`'s default `KDBBASEPORT` from `6000` to `6010`. Every process port in `process.csv` is `{KDBBASEPORT}+offset`, so this shifts every demo process's port by 10 (e.g. `rdb1` `6002` -> `6012`).
- Updates `docs/torq-demo.md`'s port table and examples to match.

## Test plan
- [x] `scripts/torq_demo.sh start all` brings up all 13 default processes
- [x] Live query against `rdb1` on the new port `6012` confirms the shift took effect
- [x] `scripts/torq_demo.sh stop all` shuts everything down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)