### PR TITLE
Add fxfeed1: a second torq_demo.sh process publishing FX quotes

### DIFF
--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -36,13 +36,17 @@ elsewhere in this repo for `src/`/`tests/` - plus `envsubst` and `rlwrap`
 
 ## What actually starts
 
-By default (`start all`) only the 13 processes marked `startwithall=1` in
-`lib/torq-finance-starter-pack/appconfig/process.csv` come up - the vendored
-README explains why: the KDB-X community edition's connection limits mean
-`monitor1`, `reporter1`, `filealerter1`, `dqc1`/`dqcdb1`, `dqe1`/`dqedb1`
-stay off unless you have a fully-licensed kdb+/KDB-X. `killtick` and
-`tpreplay1` are on-demand utility processes, not part of the standing
-stack, so they also don't auto-start.
+By default (`start all`) 14 processes come up: the 13 marked
+`startwithall=1` in the vendored
+`lib/torq-finance-starter-pack/appconfig/process.csv`, plus `fxfeed1` -
+uqf's own addition, appended as one extra row to a *copy* of that csv that
+`torq_demo.sh` generates on the fly (never editing the vendored file
+itself; see the script's `generated_procs` section). The vendored README
+explains why the rest stay off: the KDB-X community edition's connection
+limits mean `monitor1`, `reporter1`, `filealerter1`, `dqc1`/`dqcdb1`,
+`dqe1`/`dqedb1` stay off unless you have a fully-licensed kdb+/KDB-X.
+`killtick` and `tpreplay1` are on-demand utility processes, not part of the
+standing stack, so they also don't auto-start.
 
 Default ports (base `6010`, override with `TORQ_DEMO_PORT=<n>
 scripts/torq_demo.sh start all`):
@@ -57,10 +61,37 @@ scripts/torq_demo.sh start all`):
 | 6016 | sort1 | sorts data before writedown |
 | 6017 | gateway1 | single query entry point across hdb/rdb |
 | 6021 | housekeeping1 | log/process housekeeping |
-| 6024 | feed1 | the dummy feed generating simulated quotes/trades |
+| 6024 | feed1 | the vendored dummy feed - simulated equity quotes/trades |
 | 6025 | sctp1 | segmented chained tickerplant |
 | 6026 / 6027 | sortworker1/2 | sort worker pool |
 | 6028 | metrics1 | metrics collector |
+| 6029 | fxfeed1 | uqf's own feed - simulated FX quotes (see below) |
+
+## fxfeed1 - adding your own row-generating process
+
+`scripts/torq_fx_feed.q` is a second, independent feed process publishing
+synthetic top-of-book quotes for `EURUSD`/`GBPUSD`/`USDJPY`/`AUDUSD` (a
+small random walk around a fixed spot, `+/-` 1 pip wide) into the same
+`quote` table the vendored `feed1` already writes equity quotes into -
+`sym` is just a symbol column, so FX pairs and equity tickers coexist in
+one table with no schema change. It's the concrete worked example for "how
+do I add a process that publishes rows": it mirrors
+`lib/torq-finance-starter-pack/code/tick/feed.q`'s own pattern exactly -
+
+1. find the tickerplant via discovery: `.servers.startupdepcycles[...]` /
+   `.servers.gethandlebytype[...]`
+2. build one row per pair as plain vectors (see the file's own comment on
+   why they must stay vectors, not dicts keyed by pair - a dict here
+   silently produces a `length` error on insert, the hard way to find out)
+3. publish with `h (`.u.upd;`quote;data)`
+4. repeat on a timer: `.timer.repeat[...]`
+
+To add your own: copy `torq_fx_feed.q`'s shape, drop the new file anywhere
+under `scripts/` (it's referenced by absolute path, not `KDBAPPCODE`, so it
+doesn't need to live inside either vendored `lib/` tree), and add a line
+for it to `torq_demo.sh`'s `generated_procs` section (pick a free port
+offset - `docs/torq-demo.md`'s table above lists every offset already
+taken).
 
 ## Connecting
 
@@ -72,6 +103,7 @@ q session:
 ```
 q)h:hopen `:localhost:6012:admin:admin        / rdb1 - today's live ticks
 q)h "select count i by sym from quote"
+q)h "select from quote where sym in `EURUSD`GBPUSD`USDJPY`AUDUSD"  / fxfeed1's rows
 q)hclose h
 ```
 

--- a/scripts/torq_demo.sh
+++ b/scripts/torq_demo.sh
@@ -72,6 +72,16 @@ mkdir -p "$torq_data/logs" "$torq_data/tplogs" "$torq_data/wdbhdb"
 
 kdb_base_port="${TORQ_DEMO_PORT:-6010}"
 
+# Extend (never edit in place) the vendored process.csv with uqf's own
+# extra processes - currently just fxfeed1 (scripts/torq_fx_feed.q), a
+# second row-generating process publishing synthetic FX quotes into the
+# same `quote` table feed1 already writes equity quotes into. Port
+# {KDBBASEPORT}+19 is the one offset the vendored csv leaves free (0-18,
+# 20-23 are all taken - see docs/torq-demo.md's port table).
+generated_procs="$torq_data/process.csv"
+cp "$TORQAPPHOME/appconfig/process.csv" "$generated_procs"
+echo "localhost,{KDBBASEPORT}+19,feed,fxfeed1,,1,0,,,\${UQFSCRIPTS}/torq_fx_feed.q,1,,q" >>"$generated_procs"
+
 # torq.sh unconditionally sources $SETENV (defaulting to lib/torq/setenv.sh,
 # which would overwrite TORQAPPHOME/TORQPROCESSES/etc back to lib/torq's own
 # defaults) - so generate our own setenv.sh into the gitignored data dir,
@@ -82,6 +92,7 @@ cat >"$generated_setenv" <<EOF
 export TORQHOME="$TORQHOME"
 export TORQAPPHOME="$TORQAPPHOME"
 export TORQDATA="$torq_data"
+export UQFSCRIPTS="$script_dir"
 export KDBCONFIG="$TORQHOME/config"
 export KDBCODE="$TORQHOME/code"
 export KDBAPPCONFIG="$TORQAPPHOME/appconfig"
@@ -96,7 +107,7 @@ export KDBDQCDB="$torq_data/dqe/dqcdb/database"
 export KDBDQEDB="$torq_data/dqe/dqedb/database"
 export KDBBASEPORT="$kdb_base_port"
 export KDBSTACKID="-stackid \${KDBBASEPORT}"
-export TORQPROCESSES="$TORQAPPHOME/appconfig/process.csv"
+export TORQPROCESSES="$generated_procs"
 export RLWRAP="rlwrap"
 export QCON="qcon"
 export QCMD="q"

--- a/scripts/torq_fx_feed.q
+++ b/scripts/torq_fx_feed.q
@@ -1,0 +1,46 @@
+/ torq_fx_feed.q - a second, independent row-generating process for the
+/ TorQ-Finance-Starter-Pack demo (see docs/torq-demo.md), alongside the
+/ vendored pack's own code/tick/feed.q. Publishes synthetic top-of-book FX
+/ quotes for a handful of currency pairs into the same generic `quote`
+/ table feed.q already writes equity quotes into (schema: time, sym, bid,
+/ ask, bsize, asize, mode, ex, src - see
+/ lib/torq-finance-starter-pack/database.q) - sym is just a symbol column,
+/ so FX pairs and equity tickers coexist in the one table with no schema
+/ change needed.
+/ .
+/ Not loaded by src/init.q or anything else uqf itself runs - this is a
+/ TorQ demo process, registered only in the process.csv torq_demo.sh
+/ generates on the fly (appending one row to a copy of the vendored csv,
+/ never editing lib/torq-finance-starter-pack/appconfig/process.csv
+/ itself), port {KDBBASEPORT}+19. Mirrors feed.q's own
+/ discover-tickerplant-then-timer pattern exactly, so it's the concrete
+/ worked example for "how do I add a process that publishes rows" - copy
+/ this file's shape for a new one.
+
+/ pairs/spot/pip are parallel plain vectors (not dicts keyed by pairs) so
+/ that bid/ask stay plain float vectors too - a dict here would silently
+/ turn bid/ask into dicts as well, which .u.upd rejects with a length
+/ error when inserting into the plain quote table (caught the hard way -
+/ see git history for this file).
+pairs:`EURUSD`GBPUSD`USDJPY`AUDUSD
+spot:1.0850 1.2650 149.50 0.6550
+pip:0.0001 0.0001 0.01 0.0001
+size_unit:1000000
+
+/ small symmetric random walk per tick, +/-5bp of current spot
+drift_one:{[s] s*1+0.0005*-1+2*rand 1f}
+
+publish_quote:{[]
+ spot::drift_one each spot;
+ n:count pairs;
+ bid:spot-pip;
+ ask:spot+pip;
+ h (`.u.upd;`quote;(pairs;bid;ask;n#size_unit;n#size_unit;n#" ";n#"N";n#`UQFFX))
+ }
+
+/- use the discovery service to find the tickerplant to publish data to,
+/  exactly as feed.q does
+.servers.startupdepcycles[`segmentedtickerplant;10;0W];
+h:.servers.gethandlebytype[`segmentedtickerplant;`any];
+
+.timer.repeat[.proc.cp[];0Wp;0D00:00:00.500;(`publish_quote;`);"Publish FX Feed"];


### PR DESCRIPTION
## Summary
- Adds `scripts/torq_fx_feed.q`, a second row-generating process for the TorQ demo, mirroring the vendored `feed1`'s own discover-tickerplant-then-timer pattern - publishes synthetic top-of-book `EURUSD`/`GBPUSD`/`USDJPY`/`AUDUSD` quotes into the same generic `quote` table `feed1` already writes equity quotes into.
- `scripts/torq_demo.sh` now generates its own `process.csv` (a copy of the vendored one plus one extra row for `fxfeed1`, port `{KDBBASEPORT}+19`) instead of pointing at the vendored file directly, so `lib/torq-finance-starter-pack` stays untouched. Exports a new `UQFSCRIPTS` var so the new row can reference its `.q` file the same `envsubst`-driven way every other row does.
- Found and fixed a real bug along the way: `pairs`/`spot`/`pip` were originally dicts keyed by pair symbol, which silently turned `bid`/`ask` into dicts too - `.u.upd` rejected every message with a bare `length` error until `spot`/`pip` became plain parallel vectors.
- Updates `docs/torq-demo.md`: `fxfeed1`'s port, a new "adding your own row-generating process" section using it as the worked example.

## Test plan
- [x] `./q tests/run_tests.q` passes (296/296, PeachQ)
- [x] `scripts/torq_demo.sh start all` brings up all 14 processes including `fxfeed1`
- [x] Live query against `rdb1` confirms FX quotes for all 4 pairs are flowing
- [x] `scripts/torq_demo.sh stop all` shuts everything down cleanly, no leftover processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)