### PR TITLE
Add a generic list command - not just processes

### DIFF
--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -54,6 +54,8 @@ summary [--port N]                    rich status table (up/down, pid, port)
 print [PROCS] [--port N]              show exact startup command line(s), no-op otherwise
 clean                                 wipe scripts/output/torq-demo/
 query EXPR --port N                   run a synchronous q expression against a process
+list [KIND] [--port N]                list every item of KIND ('processes', 'fields',
+                                       'overrides', 'env') - no argument shows the kinds
 config-get PROCNAME [FIELD] [--port N] [--raw]  show a process's effective process.csv row
                                                  (or one field), with placeholders resolved
                                                  unless --raw
@@ -65,6 +67,29 @@ raw -- ARGS...                        pass any other torq.sh verb straight throu
 `PROCS` is `all` or a space-separated list of process names. `--port` sets
 `KDBBASEPORT` (default `6010`, see the port table below). Full `--help` is
 available on the command itself and on every subcommand.
+
+## Listing things
+
+`list` (no argument) prints the kinds it knows about; `list KIND` lists
+every item of that kind - not just processes:
+
+```
+uv run --project python/torq_orchestrator python/torq_orchestrator/torq_demo.py list
+uv run --project python/torq_orchestrator python/torq_orchestrator/torq_demo.py list processes
+```
+
+- `processes` - every process's `procname`/`proctype`/`port`/`startwithall`,
+  resolved and with any `config-set` overrides applied - the full set
+  `config-get`/`config-set`/`start <procname>` accept, without already
+  needing to know a name ahead of time
+- `fields` - `process.csv`'s valid columns (what `config-set`'s `FIELD`
+  argument accepts)
+- `overrides` - every `config-set` override currently in effect
+- `env` - `build_env()`'s resolved `KDBBASEPORT`/`KDBHDB`/... values (the
+  same env `config-get`'s placeholder resolution and `torq.sh` itself use)
+
+New kinds are one function + one `core.LISTABLE_KINDS` entry, not a new
+CLI command each time - see `core.py`'s `_list_*` functions.
 
 ## What actually starts
 

--- a/python/torq_orchestrator/README.md
+++ b/python/torq_orchestrator/README.md
@@ -61,12 +61,23 @@ summary [--port N]                    rich status table (up/down, pid, port)
 print [PROCS] [--port N]              show exact startup command line(s)
 clean                                 wipe ../../scripts/output/torq-demo/
 query EXPR --port N                   run a synchronous q expression
+list [KIND]                           list every item of KIND - no argument shows the kinds
 config-get PROCNAME [FIELD] [--raw]   show a process's effective process.csv row, resolved
 config-set PROCNAME FIELD VALUE       persist a process.csv field override
 raw -- ARGS...                        anything else torq.sh supports
 ```
 
 `--help` on the command itself or any subcommand has the full picture.
+
+## Listing things
+
+`list` isn't limited to processes - it dispatches on a small registry
+(`core.LISTABLE_KINDS`), currently `processes` (procname/proctype/port/
+startwithall, resolved and with overrides applied - the default), `fields`
+(`process.csv`'s valid `config-set` columns), `overrides` (every
+`config-set` override in effect), and `env` (`build_env()`'s resolved
+`KDBBASEPORT`/`KDBHDB`/... values). Adding a new kind is one function plus
+one registry entry - see `core.py`'s `_list_*` functions.
 
 ## Config setters
 

--- a/python/torq_orchestrator/src/torq_orchestrator/core.py
+++ b/python/torq_orchestrator/src/torq_orchestrator/core.py
@@ -231,6 +231,72 @@ def set_process_config(paths: TorqDemoPaths, procname: str, field: str, value: s
     log.info("set {}.{} = {}", procname, field, value)
 
 
+# ---------------------------------------------------------------------------
+# list_items(paths, kind) - generic listing, not just processes: a small
+# registry of kind -> (paths, base_port) -> list[dict], so a new listable
+# thing is one function + one registry entry, not a new CLI command/MCP
+# tool each time.
+# ---------------------------------------------------------------------------
+
+
+def _list_processes(paths: TorqDemoPaths, base_port: int) -> list[dict[str, str]]:
+    env = build_env(paths, base_port=base_port)
+    overrides = _read_overrides(paths)
+    items = []
+    for row in _base_process_rows(paths):
+        eff = dict(row)
+        eff.update(overrides.get(row["procname"], {}))
+        eff = resolve_process_config(eff, env)
+        items.append(
+            {
+                "procname": eff["procname"],
+                "proctype": eff["proctype"],
+                "port": eff["port"],
+                "startwithall": eff["startwithall"],
+            }
+        )
+    return items
+
+
+def _list_fields(paths: TorqDemoPaths, base_port: int) -> list[dict[str, str]]:
+    return [{"field": f} for f in PROCESS_CSV_FIELDS]
+
+
+def _list_overrides(paths: TorqDemoPaths, base_port: int) -> list[dict[str, str]]:
+    return [
+        {"procname": procname, "field": field, "value": value}
+        for procname, fields in _read_overrides(paths).items()
+        for field, value in fields.items()
+    ]
+
+
+def _list_env(paths: TorqDemoPaths, base_port: int) -> list[dict[str, str]]:
+    env = build_env(paths, base_port=base_port)
+    return [{"name": name, "value": value} for name, value in env.items()]
+
+
+LISTABLE_KINDS: dict[str, Any] = {
+    "processes": _list_processes,
+    "fields": _list_fields,
+    "overrides": _list_overrides,
+    "env": _list_env,
+}
+
+
+def list_items(
+    paths: TorqDemoPaths, kind: str, base_port: int = DEFAULT_BASE_PORT
+) -> list[dict[str, str]]:
+    """List every item of *kind* - 'processes' (procname/proctype/port/
+    startwithall, resolved+overridden), 'fields' (process.csv's valid
+    column names, for config-set), 'overrides' (every process_overrides.csv
+    entry currently set), or 'env' (build_env()'s resolved KDBBASEPORT/
+    KDBHDB/... values). See LISTABLE_KINDS for the full, extensible set.
+    """
+    if kind not in LISTABLE_KINDS:
+        raise TorqDemoError(f"unknown list kind {kind!r} - {sorted(LISTABLE_KINDS)}")
+    return LISTABLE_KINDS[kind](paths, base_port)
+
+
 def build_env(paths: TorqDemoPaths, base_port: int = DEFAULT_BASE_PORT) -> dict[str, str]:
     """The env vars torq.sh (and process.csv's ${VAR}/{VAR}+N placeholders)
     resolve against - pure, no filesystem writes. bootstrap() calls this and

--- a/python/torq_orchestrator/tests/test_core.py
+++ b/python/torq_orchestrator/tests/test_core.py
@@ -144,3 +144,43 @@ def test_set_process_config_survives_bootstrap_and_flows_into_generated_csv(
     with fake_paths.generated_procs.open(newline="") as f:
         generated_rows = {r["procname"]: r for r in csv.DictReader(f)}
     assert generated_rows["fxfeed1"]["startwithall"] == "0"
+
+
+def test_list_items_unknown_kind_raises(fake_paths: core.TorqDemoPaths):
+    with pytest.raises(core.TorqDemoError):
+        core.list_items(fake_paths, "not_a_kind")
+
+
+def test_list_processes_includes_vendored_and_fxfeed1_resolved(fake_paths: core.TorqDemoPaths):
+    items = core.list_items(fake_paths, "processes", base_port=7000)
+    by_name = {item["procname"]: item for item in items}
+    assert set(by_name) == {"discovery1", "fxfeed1"}
+    assert by_name["discovery1"]["port"] == "7000"
+    assert by_name["fxfeed1"]["port"] == str(7000 + core.FXFEED_PORT_OFFSET)
+
+
+def test_list_processes_reflects_overrides(fake_paths: core.TorqDemoPaths):
+    core.set_process_config(fake_paths, "fxfeed1", "startwithall", "0")
+    items = core.list_items(fake_paths, "processes")
+    by_name = {item["procname"]: item for item in items}
+    assert by_name["fxfeed1"]["startwithall"] == "0"
+
+
+def test_list_fields_matches_process_csv_fields(fake_paths: core.TorqDemoPaths):
+    items = core.list_items(fake_paths, "fields")
+    assert [item["field"] for item in items] == list(core.PROCESS_CSV_FIELDS)
+
+
+def test_list_overrides_empty_then_populated(fake_paths: core.TorqDemoPaths):
+    assert core.list_items(fake_paths, "overrides") == []
+
+    core.set_process_config(fake_paths, "discovery1", "port", "9999")
+    items = core.list_items(fake_paths, "overrides")
+    assert items == [{"procname": "discovery1", "field": "port", "value": "9999"}]
+
+
+def test_list_env_includes_kdbbaseport(fake_paths: core.TorqDemoPaths):
+    items = core.list_items(fake_paths, "env", base_port=7000)
+    by_name = {item["name"]: item["value"] for item in items}
+    assert by_name["KDBBASEPORT"] == "7000"
+    assert by_name["KDBHDB"] == str(fake_paths.torqdata / "hdb")

--- a/python/torq_orchestrator/torq_demo.py
+++ b/python/torq_orchestrator/torq_demo.py
@@ -178,6 +178,35 @@ def config_get(
     console.print(table)
 
 
+@app.command("list")
+def list_items(
+    kind: Annotated[
+        str | None, typer.Argument(help="'processes', 'fields', 'overrides', or 'env'")
+    ] = None,
+    port: PortOpt = core.DEFAULT_BASE_PORT,
+) -> None:
+    """List every item of KIND - run with no argument to see the available
+    kinds. Not just processes: 'fields' lists process.csv's valid config-set
+    columns, 'overrides' lists every process_overrides.csv entry currently
+    set, 'env' lists build_env()'s resolved KDBBASEPORT/KDBHDB/... values.
+    """
+    if kind is None:
+        console.print(f"Available kinds: {', '.join(sorted(core.LISTABLE_KINDS))}")
+        return
+    try:
+        items = core.list_items(_paths(), kind, base_port=port)
+    except core.TorqDemoError as exc:
+        _die(exc)
+        return
+    table = Table(title=f"{kind} ({len(items)})")
+    if items:
+        for col in items[0]:
+            table.add_column(col)
+        for item in items:
+            table.add_row(*item.values())
+    console.print(table)
+
+
 @app.command("config-set")
 def config_set(procname: str, field: str, value: str) -> None:
     """Set one process.csv field for *procname* (persisted to

--- a/python/torq_orchestrator/torq_demo_mcp.py
+++ b/python/torq_orchestrator/torq_demo_mcp.py
@@ -135,5 +135,26 @@ def torq_demo_set_config(procname: str, field: str, value: str) -> str:
     return f"{procname}.{field} = {value}"
 
 
+@mcp.tool
+def torq_demo_list_kinds() -> list[str]:
+    """List the kinds torq_demo_list accepts - not just processes."""
+    return sorted(core.LISTABLE_KINDS)
+
+
+@mcp.tool
+def torq_demo_list(kind: str = "processes", port: int = core.DEFAULT_BASE_PORT) -> Any:
+    """List every item of *kind* - call torq_demo_list_kinds() for the full
+    set. 'processes' (procname/proctype/port/startwithall, resolved and
+    with overrides applied) is the default; 'fields' lists process.csv's
+    valid torq_demo_set_config columns; 'overrides' lists every
+    torq_demo_set_config override currently in effect; 'env' lists
+    build_env()'s resolved KDBBASEPORT/KDBHDB/... values.
+    """
+    try:
+        return core.list_items(core.default_paths(), kind, base_port=port)
+    except core.TorqDemoError as exc:
+        return {"error": str(exc)}
+
+
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
## Summary
- Previously you had to already know a `procname` to query it (`config-get` requires one) - no way to see what's actually there.
- Adds `core.list_items(paths, kind, base_port)` dispatching through a small registry, `core.LISTABLE_KINDS`, so a new listable thing is one function + one registry entry:
  - `processes` - procname/proctype/port/startwithall for every process (vendored + `fxfeed1`), resolved and with `config-set` overrides applied
  - `fields` - `process.csv`'s valid columns (what `config-set`'s `FIELD` accepts)
  - `overrides` - every `config-set` override currently in effect
  - `env` - `build_env()`'s resolved `KDBBASEPORT`/`KDBHDB`/... values
- Wired through `list [KIND]` (Typer CLI - no argument prints the available kinds) and `torq_demo_list`/`torq_demo_list_kinds` (FastMCP).

## Test plan
- [x] `./q tests/run_tests.q` passes (296/296, unaffected)
- [x] `python/torq_orchestrator`'s pytest passes (18/18, incl. 6 new tests), ruff clean
- [x] `list processes` shows all 24 processes (vendored + `fxfeed1`) with resolved ports against the real vendored `process.csv`
- [x] MCP tools verified via a live in-memory FastMCP `Client` round trip
- [x] Full `start all` / `summary` / `stop all` still verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)