### PR TITLE
Add tap1: a generic, filterable debug tap for every table hitting kdb+

### DIFF
--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -281,6 +281,34 @@ rolling/restart-aliasing correctly) and merges them through a queue; without
 printed sorted by the log's own timestamp - not wall-clock arrival order.
 `--level` filters to that level and above (`DEBUG`/`INFO`/`WARNING`/`ERROR`).
 
+### tap1 - printing every row landing in kdb+
+
+`tap1` (`torq_tap.q`) is a generic debug tap: it subscribes to some (or,
+by default, every) table on the tickerplant and logs each incoming batch
+unmodified through the same `logs` pipeline above - the table name lands
+in the log line's `id` field, so `torq-demo logs -f tap1` shows you
+literally everything being written to kdb+, and `torq-demo logs -f tap1 |
+grep quotes`-style filtering works even without narrowing the subscription
+itself. `startwithall=0` (debug utility, not part of the standing stack):
+
+```
+torq-demo start tap1
+torq-demo logs -f tap1
+```
+
+Restrict it to specific tables via the same `extras`-as-CLI-flags
+mechanism `sctp1`/others already use - no orchestrator code needed for
+the filtering itself:
+
+```
+torq-demo config-set -- tap1 extras "-tables quote wide_book"
+torq-demo restart tap1
+```
+
+(the leading `--` is needed so the CLI doesn't try to parse `-tables` as
+one of its own options). Set `extras` back to `""` to return to "every
+table".
+
 ## Adding a new process interactively
 
 `torq-demo new-process` is a console wizard for the "how do I add a

--- a/python/torq_orchestrator/src/torq_orchestrator/core.py
+++ b/python/torq_orchestrator/src/torq_orchestrator/core.py
@@ -34,6 +34,7 @@ QUOTES_FEED_PORT_OFFSET = 24  # next free offset after the vendored dqc/dqe bloc
 CROSS_ETL_PORT_OFFSET = 25  # next free offset after quotesfeed1
 WIDE_BOOK_FEED_PORT_OFFSET = 26  # next free offset after cross1
 VECTORIZE_ETL_PORT_OFFSET = 27  # next free offset after widefeed1
+TAP_PORT_OFFSET = 28  # next free offset after vectorize1
 
 # Appended (never edited in place) to a *copy* of the vendored database.q -
 # see _generated_schema_content(). Matches src/forwards.q's require_quotes_cols
@@ -309,6 +310,32 @@ def _base_process_rows(paths: TorqDemoPaths) -> list[dict[str, str]]:
             "w": "",
             "load": "${UQFSCRIPTS}/torq_vectorize_etl.q",
             "startwithall": "1",
+            "extras": "",
+            "qcmd": "q",
+        }
+    )
+    rows.append(
+        {
+            "host": "localhost",
+            "port": f"{{KDBBASEPORT}}+{TAP_PORT_OFFSET}",
+            # proctype "metrics" borrowed for the same reason as cross1's
+            # row above - a real .sub.subscribe subscriber needs
+            # .servers.startup[]'s access-listed handle to stp1.
+            "proctype": "metrics",
+            "procname": "tap1",
+            "U": "${TORQAPPHOME}/appconfig/passwords/accesslist.txt",
+            "localtime": "1",
+            "g": "0",
+            "T": "",
+            "w": "",
+            "load": "${UQFSCRIPTS}/torq_tap.q",
+            # debug/verbose utility, not part of the standing demo stack -
+            # same reasoning as killtick/tpreplay1 staying off by default.
+            "startwithall": "0",
+            # -tables t1 t2 ... restricts the tap to those tables; blank
+            # (the default) subscribes to every table - see torq_tap.q.
+            # `torq-demo config-set tap1 extras "-tables quote wide_book"`
+            # to change it.
             "extras": "",
             "qcmd": "q",
         }

--- a/python/torq_orchestrator/tests/test_core.py
+++ b/python/torq_orchestrator/tests/test_core.py
@@ -182,8 +182,8 @@ def test_bootstrap_repoints_stp1_schemafile_at_generated_copy(
 def test_next_free_port_offset_skips_taken_offsets(fake_paths: core.TorqDemoPaths):
     # fixture's vendored csv: discovery1 (bare {KDBBASEPORT}), stp1 (+1);
     # _base_process_rows also appends fxfeed1(+19)/quotesfeed1(+24)/cross1(+25)/
-    # widefeed1(+26)/vectorize1(+27)
-    assert core.next_free_port_offset(fake_paths) == core.VECTORIZE_ETL_PORT_OFFSET + 1
+    # widefeed1(+26)/vectorize1(+27)/tap1(+28)
+    assert core.next_free_port_offset(fake_paths) == core.TAP_PORT_OFFSET + 1
 
 
 def test_add_extra_process_appears_in_base_rows(fake_paths: core.TorqDemoPaths):
@@ -245,6 +245,7 @@ def test_list_processes_includes_vendored_and_fxfeed1_resolved(fake_paths: core.
         "cross1",
         "widefeed1",
         "vectorize1",
+        "tap1",
     }
     assert by_name["discovery1"]["port"] == "7000"
     assert by_name["fxfeed1"]["port"] == str(7000 + core.FXFEED_PORT_OFFSET)
@@ -252,6 +253,8 @@ def test_list_processes_includes_vendored_and_fxfeed1_resolved(fake_paths: core.
     assert by_name["cross1"]["port"] == str(7000 + core.CROSS_ETL_PORT_OFFSET)
     assert by_name["widefeed1"]["port"] == str(7000 + core.WIDE_BOOK_FEED_PORT_OFFSET)
     assert by_name["vectorize1"]["port"] == str(7000 + core.VECTORIZE_ETL_PORT_OFFSET)
+    assert by_name["tap1"]["port"] == str(7000 + core.TAP_PORT_OFFSET)
+    assert by_name["tap1"]["startwithall"] == "0"
 
 
 def test_list_processes_reflects_overrides(fake_paths: core.TorqDemoPaths):
@@ -305,6 +308,7 @@ def test_resolve_procnames_all_returns_every_process(fake_paths: core.TorqDemoPa
         "cross1",
         "widefeed1",
         "vectorize1",
+        "tap1",
     }
 
 

--- a/scripts/torq_tap.q
+++ b/scripts/torq_tap.q
@@ -1,0 +1,70 @@
+/ torq_tap.q - a generic debug tap: subscribes to some (or, by default,
+/ every) table on the tickerplant and logs each incoming batch as it
+/ arrives, unmodified - "print out all data being added to kdb". Table
+/ filter comes from process.csv's `extras` field (-tables t1 t2 ...), the
+/ same convention other processes here already use for CLI flags (e.g.
+/ sctp1's -parentproctype); blank/unset means every table. Change it live
+/ with `torq-demo config-set tap1 extras "-tables quote wide_book"` then
+/ restart tap1 - no orchestrator-side code needed for the filtering.
+/ .
+/ Not loaded by src/init.q or anything else uqf itself runs - registered
+/ only in the process.csv torq_orchestrator.core.bootstrap() generates on
+/ the fly (port {KDBBASEPORT}+28 - see TAP_PORT_OFFSET in core.py).
+/ startwithall=0 (a debug utility, not part of the standing demo stack) -
+/ start it explicitly with `torq-demo start tap1`, then watch it with
+/ `torq-demo logs -f tap1`. Each line's `id` field (see
+/ core.py's parse_log_line/_LOG_FIELDS) is the table name that ticked, so
+/ `torq-demo logs -f tap1 | grep quotes`-style filtering works even
+/ without narrowing the subscription itself.
+
+opts:.Q.opt[.z.x];
+/ blank symbol = subscribe to every table - same "no filter" convention
+/ .sub.subscribe/RDB's own default subtabs already use.
+tap_tables:$[`tables in key opts; `$opts[`tables]; `];
+
+/ receive every tapped table's ticks and log the table name (as the log
+/ line's `id` field) plus the raw batch, unmodified - .Q.s1 handles
+/ whatever shape x happens to arrive in (a table, or a list of columns;
+/ see torq_vectorize_etl.q's own comment on this ambiguity) without
+/ needing to know which.
+upd:{[t;x]
+  .lg.o[t; .Q.s1 x];
+ }
+
+tickerplanttypes:`segmentedtickerplant;
+requiredprocs:tickerplanttypes;
+tpconsleep:10;
+tpcheckcycles:0W;
+
+subscribe:{
+  if[0=count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];:()];
+  subproc:first s;
+  / tap_tables is either the blank atom `` (subscribe to everything) or a
+  / symbol vector (from -tables t1 t2 ...) - string of an atom is already
+  / flat, string of a vector needs an explicit join, or "," ends up
+  / splicing individual characters in among the table names instead of
+  / joining them (threw a 'type error the first time this shipped).
+  .lg.o[`subscribe;"tapping ",$[tap_tables~`;"all tables";", " sv string tap_tables]," on ",string subproc`procname];
+  / setschema=1b (unlike cross1/vectorize1, which pre-define their own
+  / namespaced mirror table): tap1 has no local table of its own for any
+  / of this - .sub.subscribe's createtables auto-creates a matching empty
+  / root-level table per subscribed table, which the underlying dispatch
+  / needs to exist before it'll actually call upd (confirmed empirically:
+  / without this, subscription "succeeds" and upd works fine when called
+  / manually, but never fires for real ticks - no error, just silently
+  / dropped).
+  .sub.subscribe[tap_tables;`;1b;0b;subproc]
+ };
+
+init:{
+  .servers.startupdepcycles[requiredprocs;tpconsleep;tpcheckcycles];
+  subscribe[];
+ };
+
+/ same reasoning as torq_cross_etl.q/torq_vectorize_etl.q: a real
+/ .sub.subscribe subscriber needs .servers.startup[] to open a live,
+/ access-listed handle to stp1 - tap1's proctype "metrics" in process.csv
+/ (core.py) borrows an already-credentialed type for that.
+.servers.CONNECTIONS:requiredprocs;
+.servers.startup[];
+init[];


### PR DESCRIPTION
## Summary
- `tap1` (`scripts/torq_tap.q`): subscribes to some (default: every) table on the tickerplant and logs each incoming batch unmodified, table name as the log line's `id` field - `torq-demo logs -f tap1` prints everything landing in kdb+
- Filterable without touching the process itself: `torq-demo config-set -- tap1 extras "-tables quote wide_book"` then restart, reusing the same `extras`-as-CLI-flags convention `sctp1` already uses
- `startwithall=0` - debug utility, not part of the standing stack

## Root causes found and fixed along the way
- A `.sub.subscribe` subscriber with no local mirror table of its own needs `setschema=1b` - `segmentedtickerplant`'s dispatch silently drops updates for tables that don't exist as a global variable locally, with no error logged anywhere.
- Repeated restarts of a multi-table subscriber during development left stale handles in `stp1`'s `.stpps.subrequestall`; `-25!` to a handle list containing one dead entry silently dropped delivery to *every* handle in that list, not just the dead one. A clean `stp1` restart cleared it.

## Test plan
- [x] `uv run --project python/torq_orchestrator pytest` - 39 passed
- [x] `uv run --project python/torq_orchestrator ruff check` - clean
- [x] `torq-demo start tap1` + `torq-demo logs -f tap1` - confirmed live ticks from `quote`/`quotes`/`trade`/`wide_book`/`mkt_orderbook` all printing correctly
- [x] `config-set tap1 extras "-tables quote wide_book"` + restart - confirmed the tap narrows to only those two tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zVB4cC4i69zky9BDmYctw