### PR TITLE
Nest the crypto commands into a torq-demo crypto sub-app

### DIFF
--- a/docs/torq-demo.md
+++ b/docs/torq-demo.md
@@ -378,10 +378,12 @@ process shows `down` unexpectedly.
 
 ## crypto recorder (cryptorust) - a proof of concept
 
-`torq-demo crypto-start`/`crypto-stop`/`crypto-status` are a proof of
-concept that this demo's kdb+ infra isn't TorQ/q-specific: anything that
-can speak kdb+ IPC can publish onto the same tickerplant alongside the q
-feeds above, including a process written in an entirely different
+`torq-demo crypto start`/`stop`/`status` (a nested command group, not
+flat `crypto-*` commands - these don't drive `torq.sh`/`process.csv` at
+all, a distinct enough concern to read as its own namespace) are a proof
+of concept that this demo's kdb+ infra isn't TorQ/q-specific: anything
+that can speak kdb+ IPC can publish onto the same tickerplant alongside
+the q feeds above, including a process written in an entirely different
 language, in a completely separate project. Specifically, they build and
 launch a sibling checkout of [cryptorust](https://github.com/kwojdalski/cryptorust)
 (a Rust crypto trading system - see `~/github_projects/cryptorust`) - its
@@ -389,13 +391,15 @@ own `kdb-market-data-recorder` binary (`src/bin/kdb_market_data_recorder.rs`
 there) connects live venue order books (Binance, Bybit, ...) straight to
 this demo's `stp1` over raw IPC (via the [`kxkdb`](https://github.com/KxSystems/kxkdb)
 crate) and calls `.u.upd` directly - the exact same wire protocol
-`torq_fx_feed.q`/`torq_quotes_feed.q` use, just from Rust instead of q.
+`torq_fx_feed.q`/`torq_quotes_feed.q` use, just from Rust instead of q -
+with its own reconnect-on-drop loop, so a `stp1` restart doesn't take it
+down permanently.
 
 ```
-torq-demo crypto-start                    # binance_spot, BTC-USDT/ETH-USDT by default
-torq-demo crypto-start --venues binance_spot,bybit_spot --symbols BTC-USDT
-torq-demo crypto-status
-torq-demo crypto-stop
+torq-demo crypto start                    # binance_spot, BTC-USDT/ETH-USDT by default
+torq-demo crypto start --venues binance_spot,bybit_spot --symbols BTC-USDT
+torq-demo crypto status
+torq-demo crypto stop
 ```
 
 Rows land in `crypto_book` (`time`/`venue`/`sym`/`bid_prices`/`bid_sizes`/
@@ -408,7 +412,7 @@ torq-demo query "select from crypto_book" --port <rdb1's port>
 ```
 
 Requires a `~/github_projects/cryptorust` checkout (override the path via
-`$CRYPTORUST_ROOT`) with a Rust toolchain on `PATH` - `crypto-start` runs
+`$CRYPTORUST_ROOT`) with a Rust toolchain on `PATH` - `crypto start` runs
 `cargo build` itself the first time, which can take a while. It also
 reuses this demo's own `feed:pass` credential (see `appconfig/passwords/
 feed.txt`) to authenticate against `stp1`'s access-list, same as any other

--- a/python/torq_orchestrator/README.md
+++ b/python/torq_orchestrator/README.md
@@ -92,7 +92,7 @@ config-get PROCNAME [FIELD] [--raw]   show a process's effective process.csv row
 config-set PROCNAME FIELD VALUE       persist a process.csv field override
 logs [PROCS] [-f] [-n N] [--level L]  tail out_/err_*.log through the CLI's own logger
 new-process                           interactive wizard to add a new process
-crypto-start/-stop/-status            proof of concept: cryptorust (Rust) publishing over kdb+ IPC
+crypto start/stop/status              proof of concept: cryptorust (Rust) publishing over kdb+ IPC
 raw -- ARGS...                        anything else torq.sh supports
 ```
 
@@ -153,7 +153,7 @@ torq-demo logs -f --level WARNING
 
 ## crypto recorder (cryptorust) - a proof of concept
 
-`crypto-start`/`crypto-stop`/`crypto-status` build and launch a sibling
+`crypto start`/`stop`/`status` (a nested command group) build and launch a sibling
 `~/github_projects/cryptorust` checkout's own `kdb-market-data-recorder`
 Rust binary, pointed at this demo's `stp1` - proving the kdb+ infra here
 isn't TorQ/q-specific, any process that speaks kdb+ IPC can publish onto

--- a/python/torq_orchestrator/src/torq_orchestrator/cli.py
+++ b/python/torq_orchestrator/src/torq_orchestrator/cli.py
@@ -259,7 +259,20 @@ def new_process(port: PortOpt = core.DEFAULT_BASE_PORT) -> None:
         _die(exc)
 
 
-@app.command("crypto-start")
+# Proof of concept: cryptorust (Rust, no TorQ/q involved) publishing live
+# venue order books onto stp1 over kdb+ IPC - a separate sub-app (`torq-demo
+# crypto start/stop/status`) rather than flat crypto-* commands, since these
+# don't drive torq.sh/process.csv at all (see core.py's start_crypto_recorder
+# docstring) - a distinct enough concern to read as its own namespace.
+crypto_app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    help="Proof of concept: cryptorust (Rust) publishing live order books over kdb+ IPC.",
+)
+app.add_typer(crypto_app, name="crypto")
+
+
+@crypto_app.command("start")
 def crypto_start(
     venues: Annotated[
         str, typer.Option(help="Comma-separated cryptorust venue names to connect")
@@ -273,12 +286,12 @@ def crypto_start(
     interval_ms: Annotated[int, typer.Option(help="Publish interval in milliseconds")] = 1000,
     port: PortOpt = core.DEFAULT_BASE_PORT,
 ) -> None:
-    """Proof of concept: build and launch a sibling cryptorust checkout's
-    own kdb-market-data-recorder (Rust, no TorQ/q involved) and point it at
-    this demo's stp1 - publishing live venue order books onto the same
-    kdb+ infra everything else here already runs on, into `crypto_book`
-    (see core.py's CRYPTO_BOOK_TABLE_SCHEMA). Requires a cryptorust
-    checkout - see $CRYPTORUST_ROOT in core.cryptorust_root's docstring.
+    """Build and launch a sibling cryptorust checkout's own
+    kdb-market-data-recorder and point it at this demo's stp1 - publishing
+    live venue order books onto the same kdb+ infra everything else here
+    already runs on, into `crypto_book` (see core.py's
+    CRYPTO_BOOK_TABLE_SCHEMA). Requires a cryptorust checkout - see
+    $CRYPTORUST_ROOT in core.cryptorust_root's docstring.
     """
     try:
         pid = core.start_crypto_recorder(
@@ -295,9 +308,9 @@ def crypto_start(
     console.print(f"crypto recorder started (pid {pid})")
 
 
-@app.command("crypto-stop")
+@crypto_app.command("stop")
 def crypto_stop() -> None:
-    """Stop the cryptorust recorder started by `crypto-start`."""
+    """Stop the cryptorust recorder started by `crypto start`."""
     try:
         core.stop_crypto_recorder(_paths())
     except core.TorqDemoError as exc:
@@ -306,7 +319,7 @@ def crypto_stop() -> None:
     console.print("crypto recorder stopped")
 
 
-@app.command("crypto-status")
+@crypto_app.command("status")
 def crypto_status() -> None:
     """Show whether the cryptorust recorder is running, its pid, and where
     its config/log live."""


### PR DESCRIPTION
## Summary
- `torq-demo crypto-start`/`-stop`/`-status` -> `torq-demo crypto start`/`stop`/`status`, a proper Typer sub-app rather than flat hyphenated commands
- These don't drive `torq.sh`/`process.csv` at all - they build and supervise a sibling `cryptorust` checkout's own binary - distinct enough to warrant its own command namespace
- Docs updated to match (`docs/torq-demo.md`, `python/torq_orchestrator/README.md`)

## Test plan
- [x] `uv run --project python/torq_orchestrator pytest` - 39 passed
- [x] `uv run --project python/torq_orchestrator ruff check` - clean
- [x] `torq-demo crypto --help` shows the nested `start`/`stop`/`status` command group
- [x] `torq-demo crypto status` confirmed working against the live recorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zVB4cC4i69zky9BDmYctw